### PR TITLE
feat(interview): RAG 기반 모의면접 PoC 인프라

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,12 @@ SITE_URL=https://chan99k.github.io
 # Get your client ID from: https://www.google.com/adsense/
 # Format: ca-pub-XXXXXXXXXXXXXXXX
 PUBLIC_ADSENSE_CLIENT_ID=
+
+# Supabase
+# Create at: https://supabase.com/dashboard
+PUBLIC_SUPABASE_URL=
+PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Server AI Key (personal use only)
+SERVER_ANTHROPIC_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pnpm-debug.log*
 .claude/
 .playwright-mcp/
 .omc/
+.worktrees/
 
 # Local docs
 docs/plans/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,6 +15,14 @@ export default defineConfig({
     },
     vite: {
         plugins: [tailwindcss()],
+        optimizeDeps: {
+            exclude: ['onnxruntime-node'],
+        },
+        build: {
+            rollupOptions: {
+                external: ['onnxruntime-node'],
+            },
+        },
     },
     integrations: [react(), sitemap()],
     adapter: isDev ? undefined : netlify()

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,6 @@
   NODE_VERSION = "20"
 
 [functions]
-  external_node_modules = ["@huggingface/transformers", "onnxruntime-node", "onnxruntime-common"]
   node_bundler = "esbuild"
 
 # Redirect SPA fallback for admin page

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,10 @@
 [build.environment]
   NODE_VERSION = "20"
 
+[functions]
+  external_node_modules = ["@huggingface/transformers", "onnxruntime-node", "onnxruntime-common"]
+  node_bundler = "esbuild"
+
 # Redirect SPA fallback for admin page
 [[redirects]]
   from = "/admin/*"

--- a/netlify/functions/chan99k-interview.mts
+++ b/netlify/functions/chan99k-interview.mts
@@ -1,19 +1,19 @@
 import type { Context } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
-import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
 
 const ALLOWED_ORIGINS = ['https://blog.chan99k.dev'];
 const SERVER_KEY_HEADER = 'x-server-key';
 const MODEL = 'Xenova/all-MiniLM-L6-v2';
 
-let extractor: FeatureExtractionPipeline | null = null;
+// Dynamic import to avoid bundling issues with ONNX native bindings
+let extractor: unknown = null;
 
-async function getExtractor(): Promise<FeatureExtractionPipeline> {
+async function getExtractor() {
     if (!extractor) {
-        // @ts-expect-error — pipeline() union type too complex for tsc
+        const { pipeline } = await import('@huggingface/transformers');
         extractor = await pipeline('feature-extraction', MODEL);
     }
-    return extractor;
+    return extractor as { (text: string, opts: Record<string, unknown>): Promise<{ data: Float32Array }> };
 }
 
 function getAllowedOrigins(): string[] {

--- a/netlify/functions/chan99k-interview.mts
+++ b/netlify/functions/chan99k-interview.mts
@@ -1,0 +1,120 @@
+import type { Context } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
+
+const ALLOWED_ORIGINS = ['https://blog.chan99k.dev'];
+const SERVER_KEY_HEADER = 'x-server-key';
+const MODEL = 'Xenova/all-MiniLM-L6-v2';
+
+let extractor: FeatureExtractionPipeline | null = null;
+
+async function getExtractor(): Promise<FeatureExtractionPipeline> {
+    if (!extractor) {
+        // @ts-expect-error — pipeline() union type too complex for tsc
+        extractor = await pipeline('feature-extraction', MODEL);
+    }
+    return extractor;
+}
+
+function getAllowedOrigins(): string[] {
+    const origins = [...ALLOWED_ORIGINS];
+    const deployUrl = process.env.DEPLOY_PRIME_URL;
+    if (deployUrl) origins.push(deployUrl);
+    return origins;
+}
+
+function validateOrigin(origin: string | null): boolean {
+    if (!origin) return false;
+    return getAllowedOrigins().includes(origin);
+}
+
+function addCorsHeaders(headers: Headers, origin: string): void {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, x-server-key');
+}
+
+export default async (req: Request, _context: Context) => {
+    const origin = req.headers.get('origin');
+
+    if (!validateOrigin(origin)) {
+        return new Response('Forbidden', { status: 403 });
+    }
+
+    if (req.method === 'OPTIONS') {
+        const h = new Headers();
+        addCorsHeaders(h, origin!);
+        return new Response(null, { status: 204, headers: h });
+    }
+
+    if (req.method !== 'POST') {
+        return new Response('Method not allowed', { status: 405 });
+    }
+
+    // Verify server key (personal use only)
+    const serverKey = process.env.SERVER_ANTHROPIC_API_KEY;
+    const providedKey = req.headers.get(SERVER_KEY_HEADER);
+    if (!serverKey || providedKey !== serverKey) {
+        return new Response('Forbidden', { status: 403 });
+    }
+
+    let body: { query: string; messages?: { role: string; content: string }[]; session_id?: string };
+    try {
+        body = await req.json();
+    } catch {
+        return new Response('Invalid JSON', { status: 400 });
+    }
+
+    if (!body.query || typeof body.query !== 'string') {
+        return new Response('Missing query', { status: 400 });
+    }
+
+    // 1. RAG search (server-side embedding — personal use, cold start acceptable)
+    const ext = await getExtractor();
+    const output = await ext(body.query, { pooling: 'mean', normalize: true });
+    const queryEmbedding = Array.from(output.data as Float32Array);
+
+    const supabaseUrl = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const { data: chunks } = await supabase.rpc('search_similar_chunks', {
+        query_embedding: JSON.stringify(queryEmbedding),
+        match_count: 5,
+        match_threshold: 0.5,
+    });
+
+    // 2. LLM call with server key (stream passthrough)
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': serverKey,
+            'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+            model: 'claude-sonnet-4-20250514',
+            max_tokens: 2048,
+            stream: true,
+            system: `RAG 컨텍스트:\n${JSON.stringify(chunks ?? [])}`,
+            messages: body.messages ?? [{ role: 'user', content: body.query }],
+        }),
+    });
+
+    console.log(JSON.stringify({
+        ts: new Date().toISOString(),
+        fn: 'chan99k-interview',
+        rag_chunks: (chunks ?? []).length,
+        llm_status: response.status,
+    }));
+
+    const responseHeaders = new Headers({
+        'Content-Type': response.headers.get('Content-Type') ?? 'text/event-stream',
+    });
+    addCorsHeaders(responseHeaders, origin!);
+
+    return new Response(response.body, {
+        status: response.status,
+        headers: responseHeaders,
+    });
+};

--- a/netlify/functions/chan99k-interview.mts
+++ b/netlify/functions/chan99k-interview.mts
@@ -3,18 +3,6 @@ import { createClient } from '@supabase/supabase-js';
 
 const ALLOWED_ORIGINS = ['https://blog.chan99k.dev'];
 const SERVER_KEY_HEADER = 'x-server-key';
-const MODEL = 'Xenova/all-MiniLM-L6-v2';
-
-// Dynamic import to avoid bundling issues with ONNX native bindings
-let extractor: unknown = null;
-
-async function getExtractor() {
-    if (!extractor) {
-        const { pipeline } = await import('@huggingface/transformers');
-        extractor = await pipeline('feature-extraction', MODEL);
-    }
-    return extractor as { (text: string, opts: Record<string, unknown>): Promise<{ data: Float32Array }> };
-}
 
 function getAllowedOrigins(): string[] {
     const origins = [...ALLOWED_ORIGINS];
@@ -58,7 +46,12 @@ export default async (req: Request, _context: Context) => {
         return new Response('Forbidden', { status: 403 });
     }
 
-    let body: { query: string; messages?: { role: string; content: string }[]; session_id?: string };
+    let body: {
+        query: string;
+        embedding?: number[];
+        messages?: { role: string; content: string }[];
+        session_id?: string;
+    };
     try {
         body = await req.json();
     } catch {
@@ -69,20 +62,20 @@ export default async (req: Request, _context: Context) => {
         return new Response('Missing query', { status: 400 });
     }
 
-    // 1. RAG search (server-side embedding — personal use, cold start acceptable)
-    const ext = await getExtractor();
-    const output = await ext(body.query, { pooling: 'mean', normalize: true });
-    const queryEmbedding = Array.from(output.data as Float32Array);
-
     const supabaseUrl = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
     const supabase = createClient(supabaseUrl, serviceRoleKey);
 
-    const { data: chunks } = await supabase.rpc('search_similar_chunks', {
-        query_embedding: JSON.stringify(queryEmbedding),
-        match_count: 5,
-        match_threshold: 0.5,
-    });
+    // 1. RAG search (client sends pre-computed embedding vector)
+    let chunks: unknown[] = [];
+    if (body.embedding && Array.isArray(body.embedding) && body.embedding.length === 384) {
+        const { data } = await supabase.rpc('search_similar_chunks', {
+            query_embedding: JSON.stringify(body.embedding),
+            match_count: 5,
+            match_threshold: 0.5,
+        });
+        chunks = data ?? [];
+    }
 
     // 2. LLM call with server key (stream passthrough)
     const response = await fetch('https://api.anthropic.com/v1/messages', {
@@ -96,7 +89,7 @@ export default async (req: Request, _context: Context) => {
             model: 'claude-sonnet-4-20250514',
             max_tokens: 2048,
             stream: true,
-            system: `RAG 컨텍스트:\n${JSON.stringify(chunks ?? [])}`,
+            system: `RAG 컨텍스트:\n${JSON.stringify(chunks)}`,
             messages: body.messages ?? [{ role: 'user', content: body.query }],
         }),
     });
@@ -104,7 +97,7 @@ export default async (req: Request, _context: Context) => {
     console.log(JSON.stringify({
         ts: new Date().toISOString(),
         fn: 'chan99k-interview',
-        rag_chunks: (chunks ?? []).length,
+        rag_chunks: chunks.length,
         llm_status: response.status,
     }));
 

--- a/netlify/functions/rag-search.mts
+++ b/netlify/functions/rag-search.mts
@@ -1,0 +1,120 @@
+import type { Context } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const ALLOWED_ORIGINS = ['https://blog.chan99k.dev'];
+const MAX_BODY_SIZE = 50 * 1024; // 50KB
+const MAX_EMBEDDING_DIM = 384;
+
+function getAllowedOrigins(): string[] {
+    const origins = [...ALLOWED_ORIGINS];
+    const deployUrl = process.env.DEPLOY_PRIME_URL;
+    if (deployUrl) origins.push(deployUrl);
+    return origins;
+}
+
+function validateOrigin(origin: string | null): boolean {
+    if (!origin) return false;
+    return getAllowedOrigins().includes(origin);
+}
+
+function addCorsHeaders(headers: Headers, origin: string): void {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+}
+
+export default async (req: Request, _context: Context) => {
+    const origin = req.headers.get('origin');
+
+    if (!validateOrigin(origin)) {
+        return new Response('Forbidden', { status: 403 });
+    }
+
+    if (req.method === 'OPTIONS') {
+        const headers = new Headers();
+        addCorsHeaders(headers, origin!);
+        return new Response(null, { status: 204, headers });
+    }
+
+    if (req.method !== 'POST') {
+        return new Response('Method not allowed', { status: 405 });
+    }
+
+    // Validate Supabase JWT
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+        return new Response('Unauthorized', { status: 401 });
+    }
+
+    // Read and validate body size
+    let bodyText: string;
+    try {
+        bodyText = await req.text();
+    } catch {
+        return new Response('Failed to read request body', { status: 400 });
+    }
+
+    if (bodyText.length > MAX_BODY_SIZE) {
+        return new Response('Request body too large', { status: 413 });
+    }
+
+    let body: { embedding: number[]; top_k?: number };
+    try {
+        body = JSON.parse(bodyText);
+    } catch {
+        return new Response('Invalid JSON', { status: 400 });
+    }
+
+    // Validate embedding vector
+    if (!Array.isArray(body.embedding) || body.embedding.length !== MAX_EMBEDDING_DIM) {
+        return new Response(`embedding must be a ${MAX_EMBEDDING_DIM}-dim array`, { status: 400 });
+    }
+
+    if (!body.embedding.every((v) => typeof v === 'number' && isFinite(v))) {
+        return new Response('embedding contains invalid values', { status: 400 });
+    }
+
+    const topK = Math.min(Math.max(body.top_k ?? 5, 1), 20);
+
+    const supabaseUrl = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    // Verify JWT
+    const token = authHeader.slice(7);
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+        return new Response('Invalid token', { status: 401 });
+    }
+
+    // Search via pgvector RPC
+    const { data: chunks, error: searchError } = await supabase.rpc('search_similar_chunks', {
+        query_embedding: JSON.stringify(body.embedding),
+        match_count: topK,
+        match_threshold: 0.5,
+    });
+
+    if (searchError) {
+        console.error(JSON.stringify({
+            ts: new Date().toISOString(),
+            fn: 'rag-search',
+            error: searchError.message,
+        }));
+        return new Response('Search failed', { status: 500 });
+    }
+
+    console.log(JSON.stringify({
+        ts: new Date().toISOString(),
+        fn: 'rag-search',
+        user: user.id,
+        results: (chunks ?? []).length,
+    }));
+
+    const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
+    addCorsHeaders(responseHeaders, origin!);
+
+    return new Response(JSON.stringify({ chunks: chunks ?? [] }), {
+        status: 200,
+        headers: responseHeaders,
+    });
+};

--- a/netlify/functions/session.mts
+++ b/netlify/functions/session.mts
@@ -1,0 +1,168 @@
+import type { Context } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const ALLOWED_ORIGINS = ['https://blog.chan99k.dev'];
+const MAX_BODY_SIZE = 50 * 1024;
+const MAX_CONTENT_LENGTH = 10000;
+
+function getAllowedOrigins(): string[] {
+    const origins = [...ALLOWED_ORIGINS];
+    const deployUrl = process.env.DEPLOY_PRIME_URL;
+    if (deployUrl) origins.push(deployUrl);
+    return origins;
+}
+
+function validateOrigin(origin: string | null): boolean {
+    if (!origin) return false;
+    return getAllowedOrigins().includes(origin);
+}
+
+function addCorsHeaders(headers: Headers, origin: string): void {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+}
+
+async function authenticateUser(authHeader: string | null, supabaseUrl: string, serviceRoleKey: string) {
+    if (!authHeader?.startsWith('Bearer ')) return null;
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const { data: { user } } = await supabase.auth.getUser(authHeader.slice(7));
+    return user;
+}
+
+export default async (req: Request, _context: Context) => {
+    const origin = req.headers.get('origin');
+
+    if (!validateOrigin(origin)) {
+        return new Response('Forbidden', { status: 403 });
+    }
+
+    if (req.method === 'OPTIONS') {
+        const h = new Headers();
+        addCorsHeaders(h, origin!);
+        return new Response(null, { status: 204, headers: h });
+    }
+
+    if (req.method !== 'POST') {
+        return new Response('Method not allowed', { status: 405 });
+    }
+
+    const supabaseUrl = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+
+    const user = await authenticateUser(req.headers.get('Authorization'), supabaseUrl, serviceRoleKey);
+    if (!user) {
+        return new Response('Unauthorized', { status: 401 });
+    }
+
+    // Read and validate body
+    let bodyText: string;
+    try {
+        bodyText = await req.text();
+    } catch {
+        return new Response('Failed to read request body', { status: 400 });
+    }
+
+    if (bodyText.length > MAX_BODY_SIZE) {
+        return new Response('Request body too large', { status: 413 });
+    }
+
+    let body: { action: string; session_id?: string; data?: Record<string, unknown> };
+    try {
+        body = JSON.parse(bodyText);
+    } catch {
+        return new Response('Invalid JSON', { status: 400 });
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
+    addCorsHeaders(responseHeaders, origin!);
+
+    // --- Actions ---
+
+    if (body.action === 'create') {
+        const initialQuestion = String(body.data?.initial_question ?? '').slice(0, MAX_CONTENT_LENGTH);
+
+        const { data: session, error } = await supabase.from('sessions').insert({
+            user_id: user.id,
+            status: 'active',
+            initial_question: initialQuestion,
+        }).select().single();
+
+        if (error) {
+            console.error(JSON.stringify({ ts: new Date().toISOString(), fn: 'session', action: 'create', error: error.message }));
+            return new Response(JSON.stringify({ error: 'Failed to create session' }), { status: 500, headers: responseHeaders });
+        }
+
+        // Upsert user profile
+        await supabase.from('user_profiles').upsert({
+            user_id: user.id,
+            display_name: user.user_metadata?.name ?? user.email ?? '',
+        }, { onConflict: 'user_id' });
+
+        console.log(JSON.stringify({ ts: new Date().toISOString(), fn: 'session', action: 'create', user: user.id, session: session.id }));
+        return new Response(JSON.stringify({ session_id: session.id, status: 'active' }), { headers: responseHeaders });
+    }
+
+    if (body.action === 'message') {
+        if (!body.session_id || !body.data?.content) {
+            return new Response('Missing session_id or content', { status: 400, headers: responseHeaders });
+        }
+
+        const content = String(body.data.content).slice(0, MAX_CONTENT_LENGTH);
+
+        const { error } = await supabase.from('session_messages').insert({
+            session_id: body.session_id,
+            depth: Number(body.data.depth ?? 0),
+            role: String(body.data.role ?? 'user'),
+            content,
+            message_type: String(body.data.message_type ?? 'answer'),
+            interviewer: body.data.interviewer ? String(body.data.interviewer) : null,
+            related_chunks: body.data.related_chunks ?? null,
+            score: body.data.score ?? null,
+            ordering: Number(body.data.ordering ?? 0),
+        });
+
+        if (error) {
+            console.error(JSON.stringify({ ts: new Date().toISOString(), fn: 'session', action: 'message', error: error.message }));
+            return new Response(JSON.stringify({ error: 'Failed to save message' }), { status: 500, headers: responseHeaders });
+        }
+
+        return new Response(JSON.stringify({ ok: true }), { headers: responseHeaders });
+    }
+
+    if (body.action === 'complete') {
+        if (!body.session_id) {
+            return new Response('Missing session_id', { status: 400, headers: responseHeaders });
+        }
+
+        await supabase.from('sessions').update({
+            status: 'completed',
+            total_score: body.data?.total_score != null ? Number(body.data.total_score) : null,
+            feedback: body.data?.feedback ?? null,
+            completed_at: new Date().toISOString(),
+        }).eq('id', body.session_id);
+
+        // Update user profile stats
+        const { data: sessions } = await supabase
+            .from('sessions')
+            .select('total_score')
+            .eq('user_id', user.id)
+            .eq('status', 'completed');
+
+        if (sessions && sessions.length > 0) {
+            const totalSessions = sessions.length;
+            const avgScore = sessions.reduce((s, r) => s + (r.total_score ?? 0), 0) / totalSessions;
+            await supabase.from('user_profiles').update({
+                total_sessions: totalSessions,
+                avg_score: avgScore,
+                updated_at: new Date().toISOString(),
+            }).eq('user_id', user.id);
+        }
+
+        console.log(JSON.stringify({ ts: new Date().toISOString(), fn: 'session', action: 'complete', session: body.session_id }));
+        return new Response(JSON.stringify({ ok: true, status: 'completed' }), { headers: responseHeaders });
+    }
+
+    return new Response(JSON.stringify({ error: 'Unknown action' }), { status: 400, headers: responseHeaders });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "astro-netlify-platform-starter",
             "version": "0.1.0",
             "dependencies": {
+                "@ai-sdk/anthropic": "^3.0.58",
                 "@astrojs/netlify": "^6.6.0",
                 "@astrojs/react": "^4.4.0",
                 "@astrojs/sitemap": "^3.7.0",
@@ -17,9 +18,11 @@
                 "@netlify/blobs": "^10.5.0",
                 "@netlify/functions": "^5.1.2",
                 "@react-sigma/core": "^5.0.6",
+                "@supabase/supabase-js": "^2.98.0",
                 "@tailwindcss/typography": "^0.5.19",
                 "@tailwindcss/vite": "^4.1.16",
                 "@tanstack/react-query": "^5.90.20",
+                "ai": "^6.0.116",
                 "astro": "^5.16.10",
                 "blobshape": "^1.0.0",
                 "clsx": "^2.1.1",
@@ -57,6 +60,68 @@
             "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@ai-sdk/anthropic": {
+            "version": "3.0.58",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.58.tgz",
+            "integrity": "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.8",
+                "@ai-sdk/provider-utils": "4.0.19"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/gateway": {
+            "version": "3.0.66",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
+            "integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.8",
+                "@ai-sdk/provider-utils": "4.0.19",
+                "@vercel/oidc": "3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
+        },
+        "node_modules/@ai-sdk/provider": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+            "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "json-schema": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@ai-sdk/provider-utils": {
+            "version": "4.0.19",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
+            "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/provider": "3.0.8",
+                "@standard-schema/spec": "^1.1.0",
+                "eventsource-parser": "^3.0.6"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
+            }
         },
         "node_modules/@asamuzakjp/css-color": {
             "version": "4.1.1",
@@ -4890,8 +4955,87 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@supabase/auth-js": {
+            "version": "2.98.0",
+            "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
+            "integrity": "sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/functions-js": {
+            "version": "2.98.0",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
+            "integrity": "sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/postgrest-js": {
+            "version": "2.98.0",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.98.0.tgz",
+            "integrity": "sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/realtime-js": {
+            "version": "2.98.0",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.98.0.tgz",
+            "integrity": "sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/phoenix": "^1.6.6",
+                "@types/ws": "^8.18.1",
+                "tslib": "2.8.1",
+                "ws": "^8.18.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/storage-js": {
+            "version": "2.98.0",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.98.0.tgz",
+            "integrity": "sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==",
+            "license": "MIT",
+            "dependencies": {
+                "iceberg-js": "^0.8.1",
+                "tslib": "2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@supabase/supabase-js": {
+            "version": "2.98.0",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
+            "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
+            "license": "MIT",
+            "dependencies": {
+                "@supabase/auth-js": "2.98.0",
+                "@supabase/functions-js": "2.98.0",
+                "@supabase/postgrest-js": "2.98.0",
+                "@supabase/realtime-js": "2.98.0",
+                "@supabase/storage-js": "2.98.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
         },
         "node_modules/@tailwindcss/node": {
             "version": "4.1.18",
@@ -5450,6 +5594,12 @@
             "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
             "license": "MIT"
         },
+        "node_modules/@types/phoenix": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+            "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+            "license": "MIT"
+        },
         "node_modules/@types/react": {
             "version": "19.2.8",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
@@ -5494,6 +5644,15 @@
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
@@ -5629,6 +5788,15 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@vercel/oidc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+            "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 20"
             }
         },
         "node_modules/@vitejs/plugin-react": {
@@ -5964,6 +6132,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/ai": {
+            "version": "6.0.116",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
+            "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ai-sdk/gateway": "3.0.66",
+                "@ai-sdk/provider": "3.0.8",
+                "@ai-sdk/provider-utils": "4.0.19",
+                "@opentelemetry/api": "1.9.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.76 || ^4.1.8"
             }
         },
         "node_modules/ajv": {
@@ -8184,6 +8370,15 @@
                 "bare-events": "^2.7.0"
             }
         },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/execa": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -9124,6 +9319,15 @@
                 "node": ">=16.17.0"
             }
         },
+        "node_modules/iceberg-js": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+            "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -9631,6 +9835,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/json-schema": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+            "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -14873,7 +15083,6 @@
             "version": "8.19.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
             "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "cms": "npx decap-server"
     },
     "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.58",
         "@astrojs/netlify": "^6.6.0",
         "@astrojs/react": "^4.4.0",
         "@astrojs/sitemap": "^3.7.0",
@@ -22,9 +23,11 @@
         "@netlify/blobs": "^10.5.0",
         "@netlify/functions": "^5.1.2",
         "@react-sigma/core": "^5.0.6",
+        "@supabase/supabase-js": "^2.98.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.16",
         "@tanstack/react-query": "^5.90.20",
+        "ai": "^6.0.116",
         "astro": "^5.16.10",
         "blobshape": "^1.0.0",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "preview": "astro preview",
         "astro": "astro",
         "test": "vitest run",
-        "cms": "npx decap-server"
+        "cms": "npx decap-server",
+        "sync:embeddings": "npx tsx scripts/sync-embeddings.ts"
     },
     "dependencies": {
         "@ai-sdk/anthropic": "^3.0.58",

--- a/scripts/sync-embeddings.ts
+++ b/scripts/sync-embeddings.ts
@@ -1,0 +1,183 @@
+import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { createClient } from '@supabase/supabase-js';
+
+const BLOG_DIR = 'src/content/blog';
+const QUESTION_DIR = 'src/content/questions';
+const MODEL = 'Xenova/all-MiniLM-L6-v2';
+const CHUNK_SIZE = 500;
+
+// Supabase setup
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+
+if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+// Reused from build-embeddings.ts
+function extractContent(md: string): { frontmatter: Record<string, unknown>; body: string } {
+    const match = md.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    if (!match) return { frontmatter: {}, body: md };
+
+    const fmLines = match[1].split('\n');
+    const frontmatter: Record<string, unknown> = {};
+    for (const line of fmLines) {
+        const colonIdx = line.indexOf(':');
+        if (colonIdx > 0) {
+            const key = line.slice(0, colonIdx).trim();
+            let val: unknown = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, '');
+            if (typeof val === 'string' && val.startsWith('[')) {
+                try { val = JSON.parse(val.replace(/'/g, '"')); } catch { /* keep string */ }
+            }
+            frontmatter[key] = val;
+        }
+    }
+    return { frontmatter, body: match[2] };
+}
+
+function chunkText(text: string, size: number): string[] {
+    const paragraphs = text.split(/\n{2,}/);
+    const chunks: string[] = [];
+    let current = '';
+
+    for (const para of paragraphs) {
+        const clean = para.replace(/```[\s\S]*?```/g, '[code]').replace(/[#*>`\-|]/g, '').trim();
+        if (!clean) continue;
+
+        if (current.length + clean.length > size && current) {
+            chunks.push(current.trim());
+            current = '';
+        }
+        current += clean + '\n';
+    }
+    if (current.trim()) chunks.push(current.trim());
+    return chunks;
+}
+
+async function syncBlogEmbeddings(extractor: FeatureExtractionPipeline) {
+    console.log('\n--- Syncing blog embeddings ---');
+
+    // Clear existing
+    await supabase.from('blog_embeddings').delete().neq('id', '00000000-0000-0000-0000-000000000000');
+
+    const files = readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md') || f.endsWith('.mdx'));
+    let totalChunks = 0;
+
+    for (const file of files) {
+        const md = readFileSync(join(BLOG_DIR, file), 'utf-8');
+        const { frontmatter, body } = extractContent(md);
+
+        if (frontmatter.draft === 'true' || frontmatter.draft === true) {
+            console.log(`  SKIP (draft): ${file}`);
+            continue;
+        }
+
+        const title = String(frontmatter.title ?? file);
+        const slug = file.replace(/\.(md|mdx)$/, '');
+        const chunks = chunkText(body, CHUNK_SIZE);
+
+        console.log(`  ${file}: ${chunks.length} chunks`);
+
+        for (let i = 0; i < chunks.length; i++) {
+            const output = await extractor(`${title} ${chunks[i]}`, { pooling: 'mean', normalize: true });
+            const embedding = Array.from(output.data as Float32Array);
+
+            const { error } = await supabase.from('blog_embeddings').insert({
+                slug,
+                title,
+                chunk_text: chunks[i],
+                chunk_index: i,
+                embedding: JSON.stringify(embedding),
+                metadata: { tags: frontmatter.tags ?? [], category: frontmatter.category ?? '' },
+            });
+
+            if (error) console.error(`  ERROR: ${slug}[${i}]`, error.message);
+            totalChunks++;
+        }
+    }
+
+    console.log(`Blog: ${totalChunks} chunks synced`);
+}
+
+async function syncQuestionEmbeddings(extractor: FeatureExtractionPipeline) {
+    console.log('\n--- Syncing question embeddings ---');
+
+    await supabase.from('question_embeddings').delete().neq('id', '00000000-0000-0000-0000-000000000000');
+
+    const files = readdirSync(QUESTION_DIR).filter((f) => f.endsWith('.md'));
+    let totalChunks = 0;
+
+    for (const file of files) {
+        const md = readFileSync(join(QUESTION_DIR, file), 'utf-8');
+        const { frontmatter, body } = extractContent(md);
+
+        const title = String(frontmatter.title ?? file);
+        const slug = file.replace(/\.md$/, '');
+        const answer = String(frontmatter.answer ?? '');
+
+        // Embed question title
+        const qOutput = await extractor(title, { pooling: 'mean', normalize: true });
+        await supabase.from('question_embeddings').insert({
+            question_slug: slug,
+            title,
+            chunk_text: title,
+            chunk_type: 'question',
+            embedding: JSON.stringify(Array.from(qOutput.data as Float32Array)),
+            metadata: { category: frontmatter.category, difficulty: frontmatter.difficulty },
+        });
+        totalChunks++;
+
+        // Embed answer
+        if (answer) {
+            const aOutput = await extractor(`${title} ${answer}`, { pooling: 'mean', normalize: true });
+            await supabase.from('question_embeddings').insert({
+                question_slug: slug,
+                title,
+                chunk_text: answer,
+                chunk_type: 'answer',
+                embedding: JSON.stringify(Array.from(aOutput.data as Float32Array)),
+                metadata: { category: frontmatter.category, difficulty: frontmatter.difficulty },
+            });
+            totalChunks++;
+        }
+
+        // Embed body (explanation)
+        if (body.trim()) {
+            const chunks = chunkText(body, CHUNK_SIZE);
+            for (const chunk of chunks) {
+                const cOutput = await extractor(`${title} ${chunk}`, { pooling: 'mean', normalize: true });
+                await supabase.from('question_embeddings').insert({
+                    question_slug: slug,
+                    title,
+                    chunk_text: chunk,
+                    chunk_type: 'explanation',
+                    embedding: JSON.stringify(Array.from(cOutput.data as Float32Array)),
+                    metadata: { category: frontmatter.category, difficulty: frontmatter.difficulty },
+                });
+                totalChunks++;
+            }
+        }
+
+        console.log(`  ${file}: question + answer + body`);
+    }
+
+    console.log(`Questions: ${totalChunks} chunks synced`);
+}
+
+async function main() {
+    console.log(`Loading model: ${MODEL}...`);
+    // @ts-expect-error — pipeline() union type too complex for tsc, works at runtime
+    const extractor: FeatureExtractionPipeline = await pipeline('feature-extraction', MODEL);
+
+    await syncBlogEmbeddings(extractor);
+    await syncQuestionEmbeddings(extractor);
+
+    console.log('\nDone! All embeddings synced to Supabase.');
+}
+
+main().catch(console.error);

--- a/scripts/sync-embeddings.ts
+++ b/scripts/sync-embeddings.ts
@@ -171,7 +171,7 @@ async function syncQuestionEmbeddings(extractor: FeatureExtractionPipeline) {
 
 async function main() {
     console.log(`Loading model: ${MODEL}...`);
-    // @ts-expect-error — pipeline() union type too complex for tsc, works at runtime
+    // @ts-ignore — pipeline() union type too complex for tsc, works at runtime
     const extractor: FeatureExtractionPipeline = await pipeline('feature-extraction', MODEL);
 
     await syncBlogEmbeddings(extractor);

--- a/src/components/InterviewChat.tsx
+++ b/src/components/InterviewChat.tsx
@@ -1,0 +1,347 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { supabase } from '../utils/supabase';
+import { getQueryEmbedding, type EmbeddingStatus } from '../utils/client-embeddings';
+import { INITIAL_SESSION_STATE, SESSION_CONFIG } from '../config/interview-session';
+import type { SessionState, ChatMessage } from '../config/interview-session';
+import { buildInterviewSystemPrompt } from '../utils/interview-prompt';
+import type { User } from '@supabase/supabase-js';
+
+interface Props {
+    initialQuestion: string;
+}
+
+// Reuse claude-proxy streaming pattern from src/utils/claude.ts
+async function* streamFromProxy(
+    apiKey: string,
+    system: string,
+    messages: { role: string; content: string }[],
+): AsyncGenerator<string> {
+    const response = await fetch('/.netlify/functions/claude-proxy', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-claude-api-key': apiKey,
+        },
+        body: JSON.stringify({
+            model: 'claude-sonnet-4-20250514',
+            max_tokens: 2048,
+            stream: true,
+            system,
+            messages,
+        }),
+    });
+
+    if (!response.ok) {
+        const msg = response.status === 401 ? 'API 키가 유효하지 않습니다'
+            : response.status === 429 ? '요청 한도를 초과했습니다'
+            : response.status === 403 ? '접근이 거부되었습니다'
+            : 'API 요청에 실패했습니다';
+        throw new Error(msg);
+    }
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const data = line.slice(6);
+            if (data === '[DONE]') return;
+
+            try {
+                const parsed = JSON.parse(data);
+                if (parsed.type === 'content_block_delta') {
+                    const text = parsed.delta?.text;
+                    if (text) yield text;
+                }
+            } catch {
+                // skip non-JSON lines
+            }
+        }
+    }
+}
+
+export default function InterviewChat({ initialQuestion }: Props) {
+    const [user, setUser] = useState<User | null>(null);
+    const [apiKey, setApiKey] = useState('');
+    const [session, setSession] = useState<SessionState>({ ...INITIAL_SESSION_STATE, currentQuestion: initialQuestion });
+    const [input, setInput] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [streamText, setStreamText] = useState('');
+    const [embeddingStatus, setEmbeddingStatus] = useState<EmbeddingStatus>('idle');
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+
+    // Auth state
+    useEffect(() => {
+        supabase.auth.getUser().then(({ data }) => setUser(data.user));
+        const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, s) => {
+            setUser(s?.user ?? null);
+        });
+        return () => subscription.unsubscribe();
+    }, []);
+
+    // Auto-scroll
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [session.messages, streamText]);
+
+    const handleLogin = async (provider: 'google' | 'github') => {
+        await supabase.auth.signInWithOAuth({
+            provider,
+            options: { redirectTo: window.location.origin + '/interview/chat' },
+        });
+    };
+
+    const handleSubmitAnswer = useCallback(async () => {
+        if (!input.trim() || isLoading || !user) return;
+
+        setIsLoading(true);
+        const answer = input.trim();
+        setInput('');
+
+        const userMsg: ChatMessage = {
+            role: 'user',
+            content: answer,
+            messageType: 'answer',
+            timestamp: Date.now(),
+        };
+
+        const updatedMessages = [...session.messages, userMsg];
+        setSession((s) => ({ ...s, messages: updatedMessages, status: 'searching' }));
+
+        try {
+            // 1. Create session if first answer
+            let sessionId = session.sessionId;
+            if (!sessionId) {
+                const token = (await supabase.auth.getSession()).data.session?.access_token;
+                const res = await fetch('/.netlify/functions/session', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                    body: JSON.stringify({ action: 'create', data: { initial_question: session.currentQuestion } }),
+                });
+                const data = await res.json();
+                sessionId = data.session_id;
+                setSession((s) => ({ ...s, sessionId: sessionId! }));
+            }
+
+            // 2. Client-side embedding + RAG search
+            const embedding = await getQueryEmbedding(answer, setEmbeddingStatus);
+            const token = (await supabase.auth.getSession()).data.session?.access_token;
+
+            const searchRes = await fetch('/.netlify/functions/rag-search', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify({ embedding, top_k: SESSION_CONFIG.searchTopK }),
+            });
+            const { chunks } = searchRes.ok ? await searchRes.json() : { chunks: [] };
+
+            setSession((s) => ({ ...s, status: 'evaluating' }));
+
+            // 3. Build prompt and stream LLM
+            const newDepth = session.depth + 1;
+            const systemPrompt = buildInterviewSystemPrompt({
+                question: session.currentQuestion,
+                userAnswer: answer,
+                chunks,
+                history: updatedMessages,
+                depth: newDepth,
+            });
+
+            const llmMessages = updatedMessages.map((m) => ({ role: m.role, content: m.content }));
+
+            let fullText = '';
+            for await (const chunk of streamFromProxy(apiKey, systemPrompt, llmMessages)) {
+                fullText += chunk;
+                setStreamText(fullText);
+            }
+
+            // 4. Parse AI response
+            const jsonMatch = fullText.match(/```json\n?([\s\S]*?)\n?```/) ?? fullText.match(/\{[\s\S]*\}/);
+            let aiResponse: {
+                evaluations: unknown[];
+                followUp: { interviewer: string; question: string };
+                shouldContinue: boolean;
+                overallScore: number;
+                summary: string;
+            } | null = null;
+
+            if (jsonMatch) {
+                try {
+                    aiResponse = JSON.parse(jsonMatch[1] ?? jsonMatch[0]);
+                } catch { /* fallback to raw text */ }
+            }
+
+            const assistantMsg: ChatMessage = {
+                role: 'assistant',
+                content: aiResponse ? aiResponse.summary : fullText,
+                interviewer: aiResponse?.followUp?.interviewer,
+                messageType: aiResponse?.shouldContinue ? 'evaluation' : 'feedback',
+                timestamp: Date.now(),
+            };
+
+            const newMessages = [...updatedMessages, assistantMsg];
+            const newScores = [...session.scores, aiResponse?.overallScore ?? 0];
+
+            // 5. Save to session API
+            await fetch('/.netlify/functions/session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify({
+                    action: 'message',
+                    session_id: sessionId,
+                    data: { depth: newDepth, role: 'user', content: answer, message_type: 'answer', ordering: updatedMessages.length },
+                }),
+            });
+            await fetch('/.netlify/functions/session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify({
+                    action: 'message',
+                    session_id: sessionId,
+                    data: {
+                        depth: newDepth,
+                        role: 'assistant',
+                        content: fullText,
+                        message_type: aiResponse?.shouldContinue ? 'evaluation' : 'feedback',
+                        interviewer: aiResponse?.followUp?.interviewer,
+                        score: aiResponse?.evaluations,
+                        ordering: newMessages.length,
+                    },
+                }),
+            });
+
+            // 6. Update state
+            if (aiResponse?.shouldContinue && newDepth < SESSION_CONFIG.maxDepth) {
+                setSession((s) => ({
+                    ...s,
+                    messages: newMessages,
+                    depth: newDepth,
+                    status: 'question_displayed',
+                    currentQuestion: aiResponse!.followUp.question,
+                    scores: newScores,
+                }));
+            } else {
+                await fetch('/.netlify/functions/session', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                    body: JSON.stringify({
+                        action: 'complete',
+                        session_id: sessionId,
+                        data: { total_score: Math.round(newScores.reduce((a, b) => a + b, 0) / newScores.length), feedback: aiResponse },
+                    }),
+                });
+                setSession((s) => ({ ...s, messages: newMessages, depth: newDepth, status: 'completed', scores: newScores }));
+            }
+
+            setStreamText('');
+        } catch (err) {
+            setStreamText(`Error: ${err instanceof Error ? err.message : 'Unknown error'}`);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [input, isLoading, user, apiKey, session]);
+
+    // --- Render ---
+
+    if (!user) {
+        return (
+            <div className="mx-auto max-w-2xl rounded-xl border p-6 dark:border-neutral-700">
+                <h2 className="mb-4 text-xl font-bold">AI 모의면접</h2>
+                <p className="mb-4 text-neutral-600 dark:text-neutral-400">로그인하여 개인화된 모의면접을 시작하세요.</p>
+                <div className="flex gap-2">
+                    <button onClick={() => handleLogin('google')} className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">Google 로그인</button>
+                    <button onClick={() => handleLogin('github')} className="rounded bg-neutral-800 px-4 py-2 text-white hover:bg-neutral-900">GitHub 로그인</button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="mx-auto max-w-2xl rounded-xl border p-6 dark:border-neutral-700">
+            <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-xl font-bold">AI 모의면접</h2>
+                <div className="flex items-center gap-2 text-sm text-neutral-500">
+                    {embeddingStatus === 'loading' && <span>모델 로딩...</span>}
+                    <span>Depth: {session.depth}/{SESSION_CONFIG.maxDepth}</span>
+                </div>
+            </div>
+
+            {/* API Key input */}
+            {!apiKey && (
+                <div className="mb-4 rounded bg-yellow-50 p-3 dark:bg-yellow-900/20">
+                    <label className="block text-sm font-medium">Claude API Key (BYOK)</label>
+                    <input
+                        type="password"
+                        placeholder="sk-ant-api..."
+                        className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                        onBlur={(e) => setApiKey(e.target.value)}
+                    />
+                </div>
+            )}
+
+            {/* Current question */}
+            <div className="mb-4 rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
+                <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+                    {session.status === 'completed' ? '면접이 종료되었습니다.' : session.currentQuestion}
+                </p>
+            </div>
+
+            {/* Chat messages */}
+            <div className="mb-4 max-h-96 space-y-3 overflow-y-auto">
+                {session.messages.map((msg, i) => (
+                    <div key={i} className={`rounded p-3 text-sm ${msg.role === 'user' ? 'bg-neutral-100 dark:bg-neutral-800' : 'bg-green-50 dark:bg-green-900/20'}`}>
+                        <span className="text-xs font-medium text-neutral-500">
+                            {msg.role === 'user' ? '나' : msg.interviewer ? `${msg.interviewer} 면접관` : 'AI'}
+                        </span>
+                        <p className="mt-1 whitespace-pre-wrap">{msg.content}</p>
+                    </div>
+                ))}
+                {streamText && (
+                    <div className="rounded bg-green-50 p-3 text-sm dark:bg-green-900/20">
+                        <span className="text-xs font-medium text-neutral-500">AI (응답 중...)</span>
+                        <p className="mt-1 whitespace-pre-wrap">{streamText}</p>
+                    </div>
+                )}
+                <div ref={messagesEndRef} />
+            </div>
+
+            {/* Input */}
+            {session.status !== 'completed' && (
+                <div className="flex gap-2">
+                    <textarea
+                        value={input}
+                        onChange={(e) => setInput(e.target.value)}
+                        placeholder="답변을 입력하세요..."
+                        rows={3}
+                        className="flex-1 rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                        onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSubmitAnswer(); } }}
+                    />
+                    <button
+                        onClick={handleSubmitAnswer}
+                        disabled={isLoading || !apiKey}
+                        className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+                    >
+                        {isLoading ? '...' : '제출'}
+                    </button>
+                </div>
+            )}
+
+            {session.status === 'completed' && (
+                <button
+                    onClick={() => setSession({ ...INITIAL_SESSION_STATE, currentQuestion: initialQuestion })}
+                    className="w-full rounded bg-neutral-200 py-2 text-sm dark:bg-neutral-700"
+                >
+                    새 면접 시작
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/config/interview-session.ts
+++ b/src/config/interview-session.ts
@@ -1,0 +1,41 @@
+export const SESSION_CONFIG = {
+    maxDepth: 10,
+    minDepthForFinish: 3,
+    searchTopK: 5,
+    similarityThreshold: 0.7,
+    evaluationCriteria: {
+        accuracy: 30,
+        depth: 25,
+        structure: 20,
+        practical: 15,
+        communication: 10,
+    },
+} as const;
+
+export type SessionStatus = 'idle' | 'question_displayed' | 'searching' | 'evaluating' | 'feedback' | 'completed';
+
+export interface SessionState {
+    sessionId: string | null;
+    status: SessionStatus;
+    depth: number;
+    currentQuestion: string;
+    messages: ChatMessage[];
+    scores: number[];
+}
+
+export interface ChatMessage {
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+    interviewer?: string;
+    messageType?: 'question' | 'answer' | 'evaluation' | 'feedback';
+    timestamp: number;
+}
+
+export const INITIAL_SESSION_STATE: SessionState = {
+    sessionId: null,
+    status: 'idle',
+    depth: 0,
+    currentQuestion: '',
+    messages: [],
+    scores: [],
+};

--- a/src/config/interviewers.ts
+++ b/src/config/interviewers.ts
@@ -1,0 +1,33 @@
+export interface InterviewerRole {
+    id: string;
+    name: string;
+    perspective: string;
+    focusAreas: string[];
+    promptFragment: string;
+}
+
+export const INTERVIEWER_ROLES: Record<string, InterviewerRole> = {
+    frontend: {
+        id: 'frontend',
+        name: '프론트엔드 면접관',
+        perspective: '사용자 경험, 렌더링 성능, 컴포넌트 설계 관점',
+        focusAreas: ['브라우저 동작', 'UI/UX', '상태 관리', '접근성'],
+        promptFragment: '프론트엔드 개발자의 관점에서 답변을 평가하세요. 브라우저 동작 원리, 렌더링 최적화, 컴포넌트 설계, 사용자 경험에 초점을 맞추세요.',
+    },
+    backend: {
+        id: 'backend',
+        name: '백엔드 면접관',
+        perspective: '서버 성능, 데이터 정합성, 확장성 관점',
+        focusAreas: ['API 설계', '동시성', '캐싱', '보안'],
+        promptFragment: '백엔드 개발자의 관점에서 답변을 평가하세요. API 설계, 동시성 제어, 데이터 정합성, 시스템 확장성에 초점을 맞추세요.',
+    },
+    dba: {
+        id: 'dba',
+        name: 'DBA 면접관',
+        perspective: '데이터 모델링, 쿼리 최적화, 트랜잭션 관점',
+        focusAreas: ['인덱싱', '정규화', '락', '복제'],
+        promptFragment: 'DBA의 관점에서 답변을 평가하세요. 데이터 모델링, 인덱싱 전략, 쿼리 성능, 트랜잭션 격리 수준에 초점을 맞추세요.',
+    },
+} as const;
+
+export type InterviewerId = keyof typeof INTERVIEWER_ROLES;

--- a/src/pages/interview/chat.astro
+++ b/src/pages/interview/chat.astro
@@ -1,0 +1,25 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import InterviewChat from '../../components/InterviewChat';
+import { getCollection } from 'astro:content';
+
+const questions = await getCollection('questions');
+const randomIdx = Math.floor(Math.random() * questions.length);
+const initialQuestion = questions[randomIdx]?.data.title ?? '면접 질문을 준비 중입니다...';
+---
+
+<Layout title="AI 모의면접">
+    <main class="py-8">
+        <InterviewChat client:load initialQuestion={initialQuestion} />
+    </main>
+</Layout>
+
+<script is:inline>
+    // noindex for this page
+    if (!document.querySelector('meta[name="robots"]')) {
+        const meta = document.createElement('meta');
+        meta.name = 'robots';
+        meta.content = 'noindex';
+        document.head.appendChild(meta);
+    }
+</script>

--- a/src/utils/client-embeddings.ts
+++ b/src/utils/client-embeddings.ts
@@ -1,0 +1,55 @@
+import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
+
+const MODEL = 'Xenova/all-MiniLM-L6-v2';
+
+let cachedPipeline: FeatureExtractionPipeline | null = null;
+let loadingPromise: Promise<FeatureExtractionPipeline> | null = null;
+
+export type EmbeddingStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+/**
+ * Load the embedding model (cached after first call).
+ * Safe to call multiple times — concurrent calls share the same promise.
+ */
+export async function loadEmbeddingModel(
+    onStatus?: (status: EmbeddingStatus) => void,
+): Promise<FeatureExtractionPipeline> {
+    if (cachedPipeline) {
+        onStatus?.('ready');
+        return cachedPipeline;
+    }
+
+    if (loadingPromise) {
+        onStatus?.('loading');
+        return loadingPromise;
+    }
+
+    onStatus?.('loading');
+    loadingPromise = pipeline('feature-extraction', MODEL)
+        .then((p) => {
+            cachedPipeline = p;
+            loadingPromise = null;
+            onStatus?.('ready');
+            return p;
+        })
+        .catch((err) => {
+            loadingPromise = null;
+            onStatus?.('error');
+            throw err;
+        });
+
+    return loadingPromise;
+}
+
+/**
+ * Compute a 384-dim embedding vector for the given text.
+ * Loads the model on first call (~5MB download).
+ */
+export async function getQueryEmbedding(
+    text: string,
+    onStatus?: (status: EmbeddingStatus) => void,
+): Promise<number[]> {
+    const extractor = await loadEmbeddingModel(onStatus);
+    const output = await extractor(text, { pooling: 'mean', normalize: true });
+    return Array.from(output.data as Float32Array);
+}

--- a/src/utils/interview-prompt.ts
+++ b/src/utils/interview-prompt.ts
@@ -1,0 +1,119 @@
+import { INTERVIEWER_ROLES, type InterviewerId } from '../config/interviewers';
+import { SESSION_CONFIG } from '../config/interview-session';
+import type { ChatMessage } from '../config/interview-session';
+
+interface PromptInput {
+    question: string;
+    userAnswer: string;
+    chunks: { slug: string; title: string; chunk_text: string; source: string }[];
+    history: ChatMessage[];
+    depth: number;
+    interviewers?: InterviewerId[];
+}
+
+export function buildInterviewSystemPrompt(input: PromptInput): string {
+    const activeInterviewers = (input.interviewers ?? ['frontend', 'backend', 'dba'])
+        .map((id) => INTERVIEWER_ROLES[id])
+        .filter(Boolean);
+
+    const interviewerSection = activeInterviewers
+        .map((r) => `### ${r.name}\n${r.promptFragment}`)
+        .join('\n\n');
+
+    const ragSection = input.chunks.length > 0
+        ? `\n\n## 지원자 관련 자료 (블로그/프로젝트)\n${input.chunks.map((c) =>
+            `- [${c.source}] ${c.title}: ${c.chunk_text.slice(0, 300)}`
+        ).join('\n')}`
+        : '';
+
+    const criteria = SESSION_CONFIG.evaluationCriteria;
+
+    return `당신은 AI 모의면접 시스템의 면접관 패널입니다.
+다수의 면접관이 각자의 전문 관점에서 지원자를 평가합니다.
+
+## 면접관 패널
+${interviewerSection}
+
+## 현재 면접 상태
+- 질문 깊이: ${input.depth}/${SESSION_CONFIG.maxDepth}
+- 최소 깊이: ${SESSION_CONFIG.minDepthForFinish}
+
+## 초기 질문
+${input.question}
+${ragSection}
+
+## 평가 기준 (${Object.values(criteria).reduce((a, b) => a + b, 0)}점 만점)
+- 정확성: ${criteria.accuracy}점
+- 깊이/원리: ${criteria.depth}점
+- 구조화: ${criteria.structure}점
+- 실무 연결: ${criteria.practical}점
+- 커뮤니케이션: ${criteria.communication}점
+
+## 응답 규칙
+
+각 면접관이 돌아가며 코멘트 + 꼬리질문을 합니다.
+답변의 맥락에서 자연스러운 흐름으로 다음 질문을 유도하세요.
+지원자의 블로그/프로젝트 자료가 있으면 적극 활용하세요.
+
+JSON으로 응답하세요:
+
+\`\`\`json
+{
+  "evaluations": [
+    {
+      "interviewer": "frontend|backend|dba",
+      "comment": "평가 코멘트",
+      "score": { "accuracy": 0, "depth": 0, "structure": 0, "practical": 0, "communication": 0 }
+    }
+  ],
+  "followUp": {
+    "interviewer": "다음 질문을 하는 면접관 ID",
+    "question": "꼬리질문 내용",
+    "reason": "이 질문을 하는 이유"
+  },
+  "shouldContinue": true,
+  "overallScore": 72,
+  "summary": "현재까지 종합 평가"
+}
+\`\`\`
+
+${input.depth >= SESSION_CONFIG.minDepthForFinish
+        ? '면접이 충분히 진행되었습니다. 답변 품질과 깊이에 따라 shouldContinue를 false로 설정하여 종합 피드백으로 전환할 수 있습니다.'
+        : '아직 최소 깊이에 도달하지 않았으므로 shouldContinue는 반드시 true여야 합니다.'}
+
+한국어로 응답해주세요.`;
+}
+
+export function buildFinalFeedbackPrompt(
+    history: ChatMessage[],
+    scores: number[],
+): string {
+    return `지금까지의 면접 대화를 종합하여 최종 피드백을 생성하세요.
+
+## 대화 히스토리
+${history.map((m) => `[${m.role}${m.interviewer ? ` - ${m.interviewer}` : ''}]: ${m.content}`).join('\n')}
+
+## 각 턴 점수
+${scores.map((s, i) => `Turn ${i + 1}: ${s}점`).join(', ')}
+
+JSON으로 응답하세요:
+
+\`\`\`json
+{
+  "totalScore": 75,
+  "strengths": ["강점1", "강점2", "강점3"],
+  "weaknesses": ["약점1", "약점2"],
+  "studyGuide": [
+    { "topic": "학습 주제", "reason": "이유", "resources": ["추천 키워드"] }
+  ],
+  "overallFeedback": "종합 피드백 (3-5문장)",
+  "interviewerComments": {
+    "frontend": "프론트엔드 관점 총평",
+    "backend": "백엔드 관점 총평",
+    "dba": "DBA 관점 총평"
+  }
+}
+\`\`\`
+
+한국어로 응답해주세요.`;
+}

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,23 +1,39 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-// Astro uses import.meta.env, Netlify Functions use process.env
-const supabaseUrl =
-    (typeof import.meta !== 'undefined' ? import.meta.env?.PUBLIC_SUPABASE_URL : undefined)
-    ?? process.env.SUPABASE_URL
-    ?? process.env.PUBLIC_SUPABASE_URL
-    ?? '';
+function getSupabaseUrl(): string {
+    return (typeof import.meta !== 'undefined' ? import.meta.env?.PUBLIC_SUPABASE_URL : undefined)
+        ?? process.env.SUPABASE_URL
+        ?? process.env.PUBLIC_SUPABASE_URL
+        ?? '';
+}
 
-const supabaseAnonKey =
-    (typeof import.meta !== 'undefined' ? import.meta.env?.PUBLIC_SUPABASE_ANON_KEY : undefined)
-    ?? process.env.SUPABASE_ANON_KEY
-    ?? process.env.PUBLIC_SUPABASE_ANON_KEY
-    ?? '';
+function getSupabaseAnonKey(): string {
+    return (typeof import.meta !== 'undefined' ? import.meta.env?.PUBLIC_SUPABASE_ANON_KEY : undefined)
+        ?? process.env.SUPABASE_ANON_KEY
+        ?? process.env.PUBLIC_SUPABASE_ANON_KEY
+        ?? '';
+}
 
-/** Browser client (uses anon key, respects RLS) */
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+// Lazy-initialized to avoid build-time errors when env vars are not set
+let _supabase: SupabaseClient | null = null;
+
+/** Browser client (uses anon key, respects RLS). Lazy-initialized. */
+export const supabase: SupabaseClient = new Proxy({} as SupabaseClient, {
+    get(_target, prop) {
+        if (!_supabase) {
+            const url = getSupabaseUrl();
+            const key = getSupabaseAnonKey();
+            if (!url || !key) {
+                throw new Error('Supabase URL and anon key must be set in environment variables');
+            }
+            _supabase = createClient(url, key);
+        }
+        return (_supabase as Record<string, unknown>)[prop as string];
+    },
+});
 
 /** Server client factory (uses service role key, bypasses RLS) */
-export function createServerClient() {
+export function createServerClient(): SupabaseClient {
     const url = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
     return createClient(url, serviceRoleKey);

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -28,7 +28,7 @@ export const supabase: SupabaseClient = new Proxy({} as SupabaseClient, {
             }
             _supabase = createClient(url, key);
         }
-        return (_supabase as Record<string, unknown>)[prop as string];
+        return (_supabase as unknown as Record<string, unknown>)[prop as string];
     },
 });
 

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Astro uses import.meta.env, Netlify Functions use process.env
+const supabaseUrl =
+    (typeof import.meta !== 'undefined' ? import.meta.env?.PUBLIC_SUPABASE_URL : undefined)
+    ?? process.env.SUPABASE_URL
+    ?? process.env.PUBLIC_SUPABASE_URL
+    ?? '';
+
+const supabaseAnonKey =
+    (typeof import.meta !== 'undefined' ? import.meta.env?.PUBLIC_SUPABASE_ANON_KEY : undefined)
+    ?? process.env.SUPABASE_ANON_KEY
+    ?? process.env.PUBLIC_SUPABASE_ANON_KEY
+    ?? '';
+
+/** Browser client (uses anon key, respects RLS) */
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+/** Server client factory (uses service role key, bypasses RLS) */
+export function createServerClient() {
+    const url = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+    return createClient(url, serviceRoleKey);
+}

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,134 @@
+-- 001_initial_schema.sql
+-- RAG 기반 모의면접 스키마 (Supabase SQL Editor에서 실행)
+
+-- Enable pgvector
+create extension if not exists vector;
+
+-- Blog embeddings
+create table blog_embeddings (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null,
+  title text not null,
+  chunk_text text not null,
+  chunk_index integer not null default 0,
+  embedding vector(384),
+  metadata jsonb default '{}',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index on blog_embeddings using ivfflat (embedding vector_cosine_ops) with (lists = 10);
+create index on blog_embeddings (slug);
+
+-- Question embeddings
+create table question_embeddings (
+  id uuid primary key default gen_random_uuid(),
+  question_slug text not null,
+  title text not null,
+  chunk_text text not null,
+  chunk_type text not null default 'question',
+  embedding vector(384),
+  metadata jsonb default '{}',
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index on question_embeddings using ivfflat (embedding vector_cosine_ops) with (lists = 10);
+create index on question_embeddings (question_slug);
+
+-- Sessions
+create table sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users not null,
+  status text not null default 'active',
+  initial_question text,
+  total_score integer,
+  feedback jsonb,
+  created_at timestamptz default now(),
+  completed_at timestamptz
+);
+
+create index on sessions (user_id, status);
+
+-- Session messages
+create table session_messages (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid references sessions on delete cascade not null,
+  depth integer not null default 0,
+  role text not null,
+  content text not null,
+  message_type text not null,
+  interviewer text,
+  related_chunks jsonb,
+  score jsonb,
+  created_at timestamptz default now(),
+  ordering integer not null default 0
+);
+
+create index on session_messages (session_id, ordering);
+
+-- User profiles
+create table user_profiles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users unique not null,
+  display_name text,
+  target_role text default 'developer',
+  weak_areas jsonb default '[]',
+  strong_areas jsonb default '[]',
+  total_sessions integer default 0,
+  avg_score real default 0,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- RLS policies
+alter table blog_embeddings enable row level security;
+alter table question_embeddings enable row level security;
+alter table sessions enable row level security;
+alter table session_messages enable row level security;
+alter table user_profiles enable row level security;
+
+-- Public read for embeddings
+create policy "embeddings_public_read" on blog_embeddings for select using (true);
+create policy "question_embeddings_public_read" on question_embeddings for select using (true);
+
+-- Sessions: own only
+create policy "sessions_own" on sessions for all using (auth.uid() = user_id);
+
+-- Session messages: own session only
+create policy "messages_own" on session_messages for all
+  using (session_id in (select id from sessions where user_id = auth.uid()));
+
+-- User profiles: own only
+create policy "profiles_own" on user_profiles for all using (auth.uid() = user_id);
+
+-- Similarity search function
+create or replace function search_similar_chunks(
+  query_embedding vector(384),
+  match_count integer default 5,
+  match_threshold real default 0.7
+)
+returns table (
+  id uuid,
+  slug text,
+  title text,
+  chunk_text text,
+  similarity real,
+  source text
+)
+language sql stable
+as $$
+  select id, slug, title, chunk_text,
+    1 - (embedding <=> query_embedding) as similarity,
+    'blog' as source
+  from blog_embeddings
+  where 1 - (embedding <=> query_embedding) > match_threshold
+  union all
+  select id, question_slug as slug, title, chunk_text,
+    1 - (embedding <=> query_embedding) as similarity,
+    'question' as source
+  from question_embeddings
+  where 1 - (embedding <=> query_embedding) > match_threshold
+  order by similarity desc
+  limit match_count;
+$$;


### PR DESCRIPTION
## Summary
- Supabase + pgvector + AI SDK 기반 RAG 모의면접 인프라 구축 (Batch 1-2)
- 기존 InterviewWidget은 유지하면서 `/interview/chat` 페이지를 위한 기반 작업

## Changes

### Batch 1: 의존성 + Config + 유틸리티
- `@supabase/supabase-js`, `ai`, `@ai-sdk/anthropic` 의존성 추가
- `.env.example`에 Supabase, 서버 AI 키 환경변수 추가
- `src/config/interviewers.ts` — 면접관 역할 정의 (frontend, backend, dba)
- `src/config/interview-session.ts` — 세션 상태 타입 + 설정값
- `src/utils/client-embeddings.ts` — 브라우저 Transformers.js 임베딩 (모델 캐싱)

### Batch 2: Supabase 스키마 + 클라이언트 + 동기화
- `supabase/migrations/001_initial_schema.sql` — pgvector 스키마, RLS, 유사도 검색 함수
- `src/utils/supabase.ts` — 브라우저/서버 이중 지원 Supabase 클라이언트
- `scripts/sync-embeddings.ts` — 블로그+면접질문 임베딩 Supabase 동기화 스크립트

## Remaining (별도 PR 예정)
- [ ] Task 5: RAG 검색 API (rag-search.mts)
- [ ] Task 6: 세션 API + 개인용 엔드포인트
- [ ] Task 9: InterviewChat 페이지 + 컴포넌트
- [ ] Supabase 프로젝트 생성 + OAuth 설정 (수동)

## Test plan
- [x] `npm install` 정상 완료
- [x] `npx tsc --noEmit --skipLibCheck` 타입 체크 통과
- [x] `npm run build` 빌드 성공
- [ ] Supabase 프로젝트 생성 후 `npm run sync:embeddings` 실행 테스트
- [ ] 기존 InterviewWidget 정상 동작 확인