### PR TITLE
fix(interview): token 중복 선언 런타임 오류 수정

### DIFF
--- a/src/components/InterviewChat.tsx
+++ b/src/components/InterviewChat.tsx
@@ -118,10 +118,11 @@ export default function InterviewChat({ initialQuestion }: Props) {
         setSession((s) => ({ ...s, messages: updatedMessages, status: 'searching' }));
 
         try {
+            const token = (await supabase.auth.getSession()).data.session?.access_token;
+
             // 1. Create session if first answer
             let sessionId = session.sessionId;
             if (!sessionId) {
-                const token = (await supabase.auth.getSession()).data.session?.access_token;
                 const res = await fetch('/.netlify/functions/session', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
@@ -133,7 +134,6 @@ export default function InterviewChat({ initialQuestion }: Props) {
             }
 
             // 2. Client-side embedding + RAG search (graceful degradation if model fails)
-            const token = (await supabase.auth.getSession()).data.session?.access_token;
             let chunks: unknown[] = [];
             try {
                 const embedding = await getQueryEmbedding(answer, setEmbeddingStatus);


### PR DESCRIPTION
## Summary
- try 블록 내 `const token`이 두 곳(세션 생성 if블록 내 + RAG 검색 전)에서 선언되어 런타임 에러 발생
- try 블록 최상단에서 한 번만 선언하도록 통합

## Root cause
PR #19에서 token을 try 밖으로 옮겼지만, 124줄 `if (!sessionId)` 블록 안에도 `const token` 선언이 있었음. 같은 try 스코프에서 `const` 중복 선언 → `token is not defined` 런타임 에러.

## Test plan
- [ ] `/interview/chat`에서 답변 제출 → 에러 없이 LLM 스트리밍 응답 확인