### PR TITLE
fix(interview): 상단 질문 박스에 초기 면접 주제 고정 표시

### DIFF
--- a/src/components/InterviewChat.tsx
+++ b/src/components/InterviewChat.tsx
@@ -330,7 +330,7 @@ export default function InterviewChat({ initialQuestion }: Props) {
             {/* Current question */}
             <div className="mb-4 rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
                 <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
-                    {session.status === 'completed' ? '면접이 종료되었습니다.' : session.currentQuestion}
+                    {session.status === 'completed' ? '면접이 종료되었습니다.' : initialQuestion}
                 </p>
             </div>
 


### PR DESCRIPTION
## Summary

- 꼬리질문이 올 때마다 상단 주제가 덮어씌워지는 문제 수정
- `initialQuestion`(props)을 고정 표시, 꼬리질문은 채팅 흐름에서만 노출