### PR TITLE
feat(questions): 면접 질문 은행 CRUD 구현

### DIFF
--- a/netlify/functions/questions.mts
+++ b/netlify/functions/questions.mts
@@ -62,7 +62,11 @@ export default async (req: Request, _context: Context) => {
         if (body.category) query = query.eq('category', body.category);
         if (body.difficulty) query = query.eq('difficulty', body.difficulty);
         if (body.search && typeof body.search === 'string') {
-            query = query.or(`title.ilike.%${body.search}%,question.ilike.%${body.search}%`);
+            // Sanitize PostgREST filter special chars to prevent filter injection
+            const sanitized = body.search.replace(/[%_\\(),."']/g, '');
+            if (sanitized.length > 0) {
+                query = query.or(`title.ilike.%${sanitized}%,question.ilike.%${sanitized}%`);
+            }
         }
 
         const page = Math.max(1, Number(body.page) || 1);

--- a/netlify/functions/questions.mts
+++ b/netlify/functions/questions.mts
@@ -1,0 +1,115 @@
+import type { Context } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const ALLOWED_ORIGINS = ['https://blog.chan99k.dev'];
+const PAGE_SIZE = 20;
+
+function getAllowedOrigins(): string[] {
+    const origins = [...ALLOWED_ORIGINS];
+    const deployUrl = process.env.DEPLOY_PRIME_URL;
+    if (deployUrl) origins.push(deployUrl);
+    return origins;
+}
+
+function validateOrigin(origin: string | null): boolean {
+    if (!origin) return false;
+    return getAllowedOrigins().includes(origin);
+}
+
+function addCorsHeaders(headers: Headers, origin: string): void {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+}
+
+export default async (req: Request, _context: Context) => {
+    const origin = req.headers.get('origin');
+    if (!validateOrigin(origin)) return new Response('Forbidden', { status: 403 });
+
+    if (req.method === 'OPTIONS') {
+        const h = new Headers();
+        addCorsHeaders(h, origin!);
+        return new Response(null, { status: 204, headers: h });
+    }
+
+    if (req.method !== 'POST') return new Response('Method not allowed', { status: 405 });
+
+    // Auth
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) return new Response('Unauthorized', { status: 401 });
+
+    const supabaseUrl = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL ?? '';
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const token = authHeader.slice(7);
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) return new Response('Invalid token', { status: 401 });
+
+    let body: Record<string, unknown>;
+    try { body = await req.json(); } catch { return new Response('Invalid JSON', { status: 400 }); }
+
+    const action = body.action as string;
+    const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
+    addCorsHeaders(responseHeaders, origin!);
+
+    // LIST: 질문 목록 (필터링 + 페이지네이션)
+    if (action === 'list') {
+        let query = supabase.from('interview_questions').select('*', { count: 'exact' })
+            .eq('is_active', true)
+            .order('created_at', { ascending: false });
+
+        if (body.category) query = query.eq('category', body.category);
+        if (body.difficulty) query = query.eq('difficulty', body.difficulty);
+        if (body.search && typeof body.search === 'string') {
+            query = query.or(`title.ilike.%${body.search}%,question.ilike.%${body.search}%`);
+        }
+
+        const page = Math.max(1, Number(body.page) || 1);
+        const from = (page - 1) * PAGE_SIZE;
+        query = query.range(from, from + PAGE_SIZE - 1);
+
+        const { data, error, count } = await query;
+        if (error) return new Response(JSON.stringify({ error: error.message }), { status: 500, headers: responseHeaders });
+        return new Response(JSON.stringify({ questions: data, total: count, page, pageSize: PAGE_SIZE }), { headers: responseHeaders });
+    }
+
+    // GET: 질문 상세
+    if (action === 'get') {
+        const { data, error } = await supabase.from('interview_questions').select('*').eq('id', body.id).single();
+        if (error) return new Response(JSON.stringify({ error: error.message }), { status: 404, headers: responseHeaders });
+        return new Response(JSON.stringify({ question: data }), { headers: responseHeaders });
+    }
+
+    // CREATE: 질문 생성
+    if (action === 'create') {
+        const q = body.data as Record<string, unknown>;
+        const { data, error } = await supabase.from('interview_questions').insert({
+            ...q, created_by: user.id,
+        }).select().single();
+        if (error) return new Response(JSON.stringify({ error: error.message }), { status: 400, headers: responseHeaders });
+        return new Response(JSON.stringify({ question: data }), { status: 201, headers: responseHeaders });
+    }
+
+    // UPDATE: 질문 수정
+    if (action === 'update') {
+        const q = body.data as Record<string, unknown>;
+        const { data, error } = await supabase.from('interview_questions')
+            .update({ ...q, updated_at: new Date().toISOString() })
+            .eq('id', body.id).eq('created_by', user.id)
+            .select().single();
+        if (error) return new Response(JSON.stringify({ error: error.message }), { status: 400, headers: responseHeaders });
+        return new Response(JSON.stringify({ question: data }), { headers: responseHeaders });
+    }
+
+    // DELETE: 질문 비활성화 (soft delete)
+    if (action === 'delete') {
+        const { error } = await supabase.from('interview_questions')
+            .update({ is_active: false, updated_at: new Date().toISOString() })
+            .eq('id', body.id).eq('created_by', user.id);
+        if (error) return new Response(JSON.stringify({ error: error.message }), { status: 400, headers: responseHeaders });
+        return new Response(JSON.stringify({ success: true }), { headers: responseHeaders });
+    }
+
+    return new Response('Unknown action', { status: 400, headers: responseHeaders });
+};

--- a/scripts/seed-questions.ts
+++ b/scripts/seed-questions.ts
@@ -1,0 +1,106 @@
+import { createClient } from '@supabase/supabase-js';
+import fs from 'fs';
+import path from 'path';
+
+const supabase = createClient(
+  process.env.PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const QUESTIONS_DIR = path.join(process.cwd(), 'src/content/questions');
+
+// Simple frontmatter parser (no gray-matter dependency)
+function parseFrontmatter(raw: string): { data: Record<string, any>; content: string } {
+  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+  const match = raw.match(frontmatterRegex);
+
+  if (!match) {
+    return { data: {}, content: raw };
+  }
+
+  const [, frontmatter, content] = match;
+  const data: Record<string, any> = {};
+
+  // Parse YAML-like frontmatter
+  const lines = frontmatter.split('\n');
+  let currentKey = '';
+
+  for (const line of lines) {
+    const keyMatch = line.match(/^(\w+):\s*(.*)$/);
+    if (keyMatch) {
+      const [, key, value] = keyMatch;
+      currentKey = key;
+
+      // Handle different value types
+      if (value.startsWith('"') && value.endsWith('"')) {
+        // String
+        data[key] = value.slice(1, -1);
+      } else if (value.startsWith('[')) {
+        // Array start
+        const arrayMatch = value.match(/\[(.*)\]/);
+        if (arrayMatch) {
+          data[key] = arrayMatch[1]
+            .split(',')
+            .map(v => v.trim().replace(/^"|"$/g, ''))
+            .filter(Boolean);
+        } else {
+          data[key] = [];
+        }
+      } else if (value) {
+        // Plain value
+        data[key] = value;
+      }
+    } else if (currentKey && line.trim().startsWith('-')) {
+      // Array continuation
+      if (!Array.isArray(data[currentKey])) {
+        data[currentKey] = [];
+      }
+      const itemMatch = line.match(/^\s*-\s*"?(.+?)"?\s*$/);
+      if (itemMatch) {
+        data[currentKey].push(itemMatch[1]);
+      }
+    }
+  }
+
+  return { data, content: content.trim() };
+}
+
+async function seed() {
+  const files = fs.readdirSync(QUESTIONS_DIR).filter(f => f.endsWith('.md'));
+
+  console.log(`Found ${files.length} question files`);
+
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(QUESTIONS_DIR, file), 'utf-8');
+    const { data, content } = parseFrontmatter(raw);
+
+    // Extract explanation from markdown body (## 해설 section)
+    const explanation = content.replace(/^##\s*해설\s*\n/m, '').trim();
+
+    const questionData = {
+      title: data.title,
+      question: data.title,  // title IS the question
+      answer: data.answer,
+      explanation,
+      category: data.category || 'general',
+      difficulty: data.difficulty || 'junior',
+      tags: data.tags ?? [],
+      source: data.source ?? 'curated',
+      hints: data.hints ?? [],
+      related_posts: data.relatedPosts ?? [],
+      is_active: true,
+    };
+
+    const { error } = await supabase.from('interview_questions').insert(questionData);
+
+    if (error) {
+      console.error(`Failed: ${file}`, error.message);
+    } else {
+      console.log(`Seeded: ${data.title}`);
+    }
+  }
+
+  console.log('Seeding complete');
+}
+
+seed().catch(console.error);

--- a/src/components/QuestionDetail.tsx
+++ b/src/components/QuestionDetail.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../utils/supabase';
+
+interface Question {
+    id: string;
+    title: string;
+    question: string;
+    answer: string;
+    explanation: string;
+    category: string;
+    difficulty: string;
+    tags: string[];
+    hints: string[];
+    related_posts: string[];
+}
+
+export default function QuestionDetail({ questionId }: { questionId: string }) {
+    const [question, setQuestion] = useState<Question | null>(null);
+    const [showAnswer, setShowAnswer] = useState(false);
+
+    useEffect(() => {
+        (async () => {
+            const token = (await supabase.auth.getSession()).data.session?.access_token;
+            if (!token) return;
+            const res = await fetch('/.netlify/functions/questions', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify({ action: 'get', id: questionId }),
+            });
+            if (res.ok) {
+                const data = await res.json();
+                setQuestion(data.question);
+            }
+        })();
+    }, [questionId]);
+
+    if (!question) return <p className="text-neutral-500">로딩 중...</p>;
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl font-bold">{question.title}</h1>
+                <div className="mt-2 flex gap-2 text-sm">
+                    <span className="rounded bg-blue-100 px-2 py-0.5 dark:bg-blue-900/30">{question.category}</span>
+                    <span className="rounded bg-green-100 px-2 py-0.5 dark:bg-green-900/30">{question.difficulty}</span>
+                </div>
+            </div>
+
+            {question.hints.length > 0 && (
+                <div>
+                    <h3 className="text-sm font-medium text-neutral-500">힌트</h3>
+                    <div className="mt-1 flex flex-wrap gap-1">{question.hints.map(h => <span key={h} className="rounded bg-yellow-100 px-2 py-0.5 text-xs dark:bg-yellow-900/30">{h}</span>)}</div>
+                </div>
+            )}
+
+            <div>
+                <button onClick={() => setShowAnswer(!showAnswer)} className="text-sm text-blue-600 hover:underline">
+                    {showAnswer ? '답변 숨기기' : '모범 답안 보기'}
+                </button>
+                {showAnswer && (
+                    <div className="mt-2 rounded bg-neutral-50 p-4 dark:bg-neutral-800">
+                        <p className="whitespace-pre-wrap text-sm">{question.answer}</p>
+                        {question.explanation && <p className="mt-3 whitespace-pre-wrap text-sm text-neutral-600 dark:text-neutral-400">{question.explanation}</p>}
+                    </div>
+                )}
+            </div>
+
+            <a href={`/interview/chat?q=${encodeURIComponent(question.title)}`}
+                className="inline-block rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">
+                이 질문으로 면접 시작
+            </a>
+        </div>
+    );
+}

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { supabase } from '../utils/supabase';
+
+const CATEGORIES = ['general', 'java', 'spring', 'database', 'network', 'os', 'design-pattern', 'architecture'];
+const DIFFICULTIES = ['junior', 'mid', 'senior'];
+
+interface Props {
+    editId?: string;
+    initialData?: Record<string, unknown>;
+}
+
+export default function QuestionForm({ editId, initialData }: Props) {
+    const [title, setTitle] = useState((initialData?.title as string) ?? '');
+    const [answer, setAnswer] = useState((initialData?.answer as string) ?? '');
+    const [explanation, setExplanation] = useState((initialData?.explanation as string) ?? '');
+    const [category, setCategory] = useState((initialData?.category as string) ?? 'general');
+    const [difficulty, setDifficulty] = useState((initialData?.difficulty as string) ?? 'junior');
+    const [tags, setTags] = useState((initialData?.tags as string[])?.join(', ') ?? '');
+    const [hints, setHints] = useState((initialData?.hints as string[])?.join(', ') ?? '');
+    const [isSaving, setIsSaving] = useState(false);
+    const [message, setMessage] = useState('');
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsSaving(true);
+
+        const token = (await supabase.auth.getSession()).data.session?.access_token;
+        if (!token) { setMessage('로그인 필요'); setIsSaving(false); return; }
+
+        const data = {
+            title, question: title, answer, explanation, category, difficulty,
+            tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+            hints: hints.split(',').map(h => h.trim()).filter(Boolean),
+        };
+
+        const res = await fetch('/.netlify/functions/questions', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+            body: JSON.stringify(editId ? { action: 'update', id: editId, data } : { action: 'create', data }),
+        });
+
+        if (res.ok) {
+            setMessage(editId ? '수정 완료' : '생성 완료');
+            if (!editId) window.location.href = '/interview/questions';
+        } else {
+            const err = await res.json();
+            setMessage(`오류: ${err.error}`);
+        }
+        setIsSaving(false);
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+                <label className="block text-sm font-medium">질문 *</label>
+                <input type="text" value={title} onChange={e => setTitle(e.target.value)} required
+                    className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800" />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <label className="block text-sm font-medium">카테고리</label>
+                    <select value={category} onChange={e => setCategory(e.target.value)}
+                        className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800">
+                        {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium">난이도</label>
+                    <select value={difficulty} onChange={e => setDifficulty(e.target.value)}
+                        className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800">
+                        {DIFFICULTIES.map(d => <option key={d} value={d}>{d}</option>)}
+                    </select>
+                </div>
+            </div>
+            <div>
+                <label className="block text-sm font-medium">모범 답안</label>
+                <textarea value={answer} onChange={e => setAnswer(e.target.value)} rows={4}
+                    className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800" />
+            </div>
+            <div>
+                <label className="block text-sm font-medium">해설</label>
+                <textarea value={explanation} onChange={e => setExplanation(e.target.value)} rows={4}
+                    className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800" />
+            </div>
+            <div>
+                <label className="block text-sm font-medium">태그 (쉼표 구분)</label>
+                <input type="text" value={tags} onChange={e => setTags(e.target.value)} placeholder="Collections, 동기화, Thread-safe"
+                    className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800" />
+            </div>
+            <div>
+                <label className="block text-sm font-medium">힌트 (쉼표 구분)</label>
+                <input type="text" value={hints} onChange={e => setHints(e.target.value)} placeholder="동기화, null 허용"
+                    className="mt-1 w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800" />
+            </div>
+            {message && <p className="text-sm text-blue-600">{message}</p>}
+            <button type="submit" disabled={isSaving} className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50">
+                {isSaving ? '저장 중...' : editId ? '수정' : '생성'}
+            </button>
+        </form>
+    );
+}

--- a/src/components/QuestionList.tsx
+++ b/src/components/QuestionList.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../utils/supabase';
+
+interface Question {
+    id: string;
+    title: string;
+    category: string;
+    difficulty: string;
+    tags: string[];
+    source: string;
+    created_at: string;
+}
+
+const CATEGORIES = ['general', 'java', 'spring', 'database', 'network', 'os', 'design-pattern', 'architecture'];
+const DIFFICULTIES = ['junior', 'mid', 'senior'];
+
+export default function QuestionList() {
+    const [questions, setQuestions] = useState<Question[]>([]);
+    const [total, setTotal] = useState(0);
+    const [page, setPage] = useState(1);
+    const [category, setCategory] = useState('');
+    const [difficulty, setDifficulty] = useState('');
+    const [search, setSearch] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+
+    const fetchQuestions = useCallback(async () => {
+        setIsLoading(true);
+        const token = (await supabase.auth.getSession()).data.session?.access_token;
+        if (!token) { setIsLoading(false); return; }
+
+        const res = await fetch('/.netlify/functions/questions', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ action: 'list', page, category: category || undefined, difficulty: difficulty || undefined, search: search || undefined }),
+        });
+        if (res.ok) {
+            const data = await res.json();
+            setQuestions(data.questions);
+            setTotal(data.total);
+        }
+        setIsLoading(false);
+    }, [page, category, difficulty, search]);
+
+    useEffect(() => { fetchQuestions(); }, [fetchQuestions]);
+
+    const totalPages = Math.ceil(total / 20);
+
+    return (
+        <div>
+            <div className="mb-6 flex items-center justify-between">
+                <h1 className="text-2xl font-bold">면접 질문 은행</h1>
+                <a href="/interview/questions/new" className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">질문 추가</a>
+            </div>
+
+            {/* Filters */}
+            <div className="mb-4 flex flex-wrap gap-2">
+                <input
+                    type="text" placeholder="검색..." value={search}
+                    onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+                    className="rounded border px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                />
+                <select value={category} onChange={(e) => { setCategory(e.target.value); setPage(1); }}
+                    className="rounded border px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-800">
+                    <option value="">전체 카테고리</option>
+                    {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+                </select>
+                <select value={difficulty} onChange={(e) => { setDifficulty(e.target.value); setPage(1); }}
+                    className="rounded border px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-800">
+                    <option value="">전체 난이도</option>
+                    {DIFFICULTIES.map(d => <option key={d} value={d}>{d}</option>)}
+                </select>
+            </div>
+
+            {/* Question list */}
+            {isLoading ? <p className="text-neutral-500">로딩 중...</p> : (
+                <div className="space-y-3">
+                    {questions.map(q => (
+                        <a key={q.id} href={`/interview/questions/${q.id}`}
+                            className="block rounded-lg border p-4 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/50">
+                            <h3 className="font-medium">{q.title}</h3>
+                            <div className="mt-1 flex gap-2 text-xs text-neutral-500">
+                                <span className="rounded bg-blue-100 px-1.5 py-0.5 dark:bg-blue-900/30">{q.category}</span>
+                                <span className="rounded bg-green-100 px-1.5 py-0.5 dark:bg-green-900/30">{q.difficulty}</span>
+                                {q.tags.slice(0, 3).map(t => <span key={t} className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-700">{t}</span>)}
+                            </div>
+                        </a>
+                    ))}
+                    {questions.length === 0 && <p className="text-neutral-500">질문이 없습니다.</p>}
+                </div>
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+                <div className="mt-4 flex justify-center gap-2">
+                    <button disabled={page <= 1} onClick={() => setPage(p => p - 1)}
+                        className="rounded border px-3 py-1 text-sm disabled:opacity-50 dark:border-neutral-700">이전</button>
+                    <span className="px-3 py-1 text-sm">{page} / {totalPages}</span>
+                    <button disabled={page >= totalPages} onClick={() => setPage(p => p + 1)}
+                        className="rounded border px-3 py-1 text-sm disabled:opacity-50 dark:border-neutral-700">다음</button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/pages/interview/questions/[id].astro
+++ b/src/pages/interview/questions/[id].astro
@@ -1,0 +1,13 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import QuestionDetail from '../../../components/QuestionDetail';
+
+const { id } = Astro.params;
+
+export const prerender = false;
+---
+<Layout title="질문 상세">
+  <main class="mx-auto max-w-3xl px-4 py-8">
+    <QuestionDetail client:load questionId={id!} />
+  </main>
+</Layout>

--- a/src/pages/interview/questions/index.astro
+++ b/src/pages/interview/questions/index.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import QuestionList from '../../../components/QuestionList';
+
+export const prerender = false;
+---
+<Layout title="면접 질문 은행">
+  <main class="mx-auto max-w-4xl px-4 py-8">
+    <QuestionList client:load />
+  </main>
+</Layout>

--- a/src/pages/interview/questions/new.astro
+++ b/src/pages/interview/questions/new.astro
@@ -1,0 +1,12 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import QuestionForm from '../../../components/QuestionForm';
+
+export const prerender = false;
+---
+<Layout title="질문 추가">
+  <main class="mx-auto max-w-3xl px-4 py-8">
+    <h1 class="mb-6 text-2xl font-bold">새 면접 질문</h1>
+    <QuestionForm client:load />
+  </main>
+</Layout>

--- a/supabase/migrations/002_interview_questions.sql
+++ b/supabase/migrations/002_interview_questions.sql
@@ -1,0 +1,39 @@
+-- 002_interview_questions.sql
+-- 면접 질문 은행 스키마
+
+create table interview_questions (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,                          -- 질문 제목
+  question text not null,                       -- 질문 본문
+  answer text,                                  -- 모범 답안 (optional)
+  explanation text,                             -- 해설
+  category text not null default 'general',     -- java, spring, database, network, os, design-pattern, architecture, etc.
+  difficulty text not null default 'junior',    -- junior, mid, senior
+  tags text[] default '{}',                     -- 태그 배열
+  source text default 'curated',               -- curated, community, imported
+  hints text[] default '{}',                    -- 힌트 키워드
+  related_posts text[] default '{}',            -- 관련 블로그 slug
+  is_active boolean default true,               -- 활성/비활성
+  created_by uuid references auth.users,        -- 작성자
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- 인덱스
+create index idx_questions_category on interview_questions (category);
+create index idx_questions_difficulty on interview_questions (difficulty);
+create index idx_questions_tags on interview_questions using gin (tags);
+create index idx_questions_active on interview_questions (is_active) where is_active = true;
+
+-- RLS
+alter table interview_questions enable row level security;
+
+-- 모든 인증 사용자가 활성 질문 읽기 가능
+create policy "questions_read" on interview_questions
+  for select using (is_active = true);
+
+-- 작성자만 자기 질문 수정/삭제
+create policy "questions_owner_write" on interview_questions
+  for all using (auth.uid() = created_by);
+
+-- 관리자(service_role)는 모든 작업 가능 (Netlify Function에서 사용)


### PR DESCRIPTION
## Summary
- 면접 질문 은행 DB 스키마, CRUD API, 목록/상세/편집 UI 구현
- 기존 markdown 질문을 DB로 마이그레이션하는 시드 스크립트 포함
- PostgREST 필터 인젝션 방어 포함

## Changes
- `supabase/migrations/002_interview_questions.sql`: interview_questions 테이블 + RLS + 인덱스
- `scripts/seed-questions.ts`: 기존 markdown 질문 → DB 시드 스크립트
- `netlify/functions/questions.mts`: list/get/create/update/delete CRUD API
- `src/components/QuestionList.tsx`: 질문 목록 UI (필터, 페이지네이션)
- `src/pages/interview/questions/index.astro`: 질문 목록 페이지

## Test plan
- [ ] Supabase 마이그레이션 실행 후 테이블 생성 확인
- [ ] 시드 스크립트로 기존 질문 데이터 이관
- [ ] 질문 목록/상세/생성/수정 API 동작 확인
- [ ] 검색 필터 특수문자 입력 시 에러 없음 확인

Refs: TASK-27