### PR TITLE
feat(interview): 면접관 선택 UI 구현

### DIFF
--- a/src/components/InterviewChat.tsx
+++ b/src/components/InterviewChat.tsx
@@ -373,7 +373,6 @@ export default function InterviewChat({ initialQuestion, interviewers }: Props) 
             setIsLoading(false);
         }
     }, [input, isLoading, user, apiKey, interviewers, companyName, jdText, session.currentQuestion, session.scores]);
-    }, [input, isLoading, user, apiKey, companyName, jdText, session.currentQuestion, session.scores]);
 
     // --- Render ---
 

--- a/src/components/InterviewChat.tsx
+++ b/src/components/InterviewChat.tsx
@@ -4,9 +4,11 @@ import { INITIAL_SESSION_STATE, SESSION_CONFIG } from '../config/interview-sessi
 import type { SessionState, ChatMessage } from '../config/interview-session';
 import { buildInterviewSystemPrompt } from '../utils/interview-prompt';
 import type { User } from '@supabase/supabase-js';
+import type { InterviewerId } from '../config/interviewers';
 
 interface Props {
     initialQuestion: string;
+    interviewers?: InterviewerId[];
 }
 
 // Reuse claude-proxy streaming pattern from src/utils/claude.ts
@@ -115,7 +117,7 @@ async function* streamFromServer(
     }
 }
 
-export default function InterviewChat({ initialQuestion }: Props) {
+export default function InterviewChat({ initialQuestion, interviewers }: Props) {
     const [user, setUser] = useState<User | null>(null);
     const [apiKey, setApiKey] = useState('');
     const [showApiKeyInput, setShowApiKeyInput] = useState(false);
@@ -126,6 +128,11 @@ export default function InterviewChat({ initialQuestion }: Props) {
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const isNearBottomRef = useRef(true); // Start true to auto-scroll initially
+
+    // JD context state
+    const [showJdInput, setShowJdInput] = useState(false);
+    const [companyName, setCompanyName] = useState('');
+    const [jdText, setJdText] = useState('');
 
     const sessionRef = useRef(session);
     useEffect(() => { sessionRef.current = session; }, [session]);
@@ -225,12 +232,17 @@ export default function InterviewChat({ initialQuestion }: Props) {
 
             // 3. Build prompt and stream LLM
             const newDepth = sessionRef.current.depth + 1;
+            const jdContext = companyName.trim() || jdText.trim()
+                ? { company: companyName.trim(), jd: jdText.trim() }
+                : undefined;
             const systemPrompt = buildInterviewSystemPrompt({
                 question: sessionRef.current.currentQuestion,
                 userAnswer: answer,
                 chunks,
                 history: updatedMessages,
                 depth: newDepth,
+                interviewers,
+                jdContext,
             });
 
             // Keep only recent messages to avoid exceeding input token limit
@@ -360,7 +372,7 @@ export default function InterviewChat({ initialQuestion }: Props) {
         } finally {
             setIsLoading(false);
         }
-    }, [input, isLoading, user, apiKey]);
+    }, [input, isLoading, user, apiKey, interviewers, companyName, jdText, session.currentQuestion, session.scores]);
 
     // --- Render ---
 
@@ -413,6 +425,36 @@ export default function InterviewChat({ initialQuestion }: Props) {
                     >
                         서버 키 모드로 돌아가기
                     </button>
+                </div>
+            )}
+
+            {/* JD 입력 (선택사항) - 면접 시작 전에만 표시 */}
+            {session.messages.length === 0 && (
+                <div className="mb-4 rounded-lg border border-dashed border-neutral-300 p-4 dark:border-neutral-600">
+                    <button
+                        onClick={() => setShowJdInput(!showJdInput)}
+                        className="text-sm font-medium text-neutral-600 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
+                    >
+                        {showJdInput ? '▼ 기업 맥락 접기' : '▶ 기업/채용공고 설정 (선택사항)'}
+                    </button>
+                    {showJdInput && (
+                        <div className="mt-3 space-y-2">
+                            <input
+                                type="text"
+                                placeholder="기업명 (예: 네이버, 카카오)"
+                                value={companyName}
+                                onChange={(e) => setCompanyName(e.target.value)}
+                                className="w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                            />
+                            <textarea
+                                placeholder="채용공고 또는 JD 텍스트 (붙여넣기)"
+                                value={jdText}
+                                onChange={(e) => setJdText(e.target.value)}
+                                rows={4}
+                                className="w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                            />
+                        </div>
+                    )}
                 </div>
             )}
 

--- a/src/components/InterviewPage.tsx
+++ b/src/components/InterviewPage.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import InterviewSetup from './InterviewSetup';
+import InterviewChat from './InterviewChat';
+import type { InterviewerId } from '../config/interviewers';
+
+interface Props {
+    initialQuestion: string;
+}
+
+export default function InterviewPage({ initialQuestion }: Props) {
+    const [config, setConfig] = useState<{ interviewers: InterviewerId[] } | null>(null);
+
+    if (!config) {
+        return (
+            <div className="mx-auto max-w-2xl rounded-xl border p-6 dark:border-neutral-700">
+                <h2 className="mb-4 text-xl font-bold">AI 모의면접</h2>
+                <InterviewSetup onStart={setConfig} />
+            </div>
+        );
+    }
+
+    return <InterviewChat initialQuestion={initialQuestion} interviewers={config.interviewers} />;
+}

--- a/src/components/InterviewSetup.tsx
+++ b/src/components/InterviewSetup.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { INTERVIEWER_ROLES, type InterviewerId } from '../config/interviewers';
+
+interface Props {
+    onStart: (config: { interviewers: InterviewerId[] }) => void;
+}
+
+const ALL_INTERVIEWERS = Object.keys(INTERVIEWER_ROLES) as InterviewerId[];
+
+export default function InterviewSetup({ onStart }: Props) {
+    const [selected, setSelected] = useState<InterviewerId[]>([...ALL_INTERVIEWERS]);
+
+    const toggle = (id: InterviewerId) => {
+        setSelected(prev => {
+            if (prev.includes(id)) {
+                if (prev.length <= 1) return prev; // 최소 1명
+                return prev.filter(x => x !== id);
+            }
+            if (prev.length >= 3) return prev; // 최대 3명
+            return [...prev, id];
+        });
+    };
+
+    return (
+        <div className="space-y-4">
+            <h3 className="text-sm font-medium">면접관 선택 (1~3명)</h3>
+            <div className="flex flex-wrap gap-2">
+                {ALL_INTERVIEWERS.map(id => {
+                    const role = INTERVIEWER_ROLES[id];
+                    const isSelected = selected.includes(id);
+                    return (
+                        <button
+                            key={id}
+                            onClick={() => toggle(id)}
+                            className={`rounded-lg border px-3 py-2 text-sm transition-colors ${
+                                isSelected
+                                    ? 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-300'
+                                    : 'border-neutral-300 text-neutral-500 dark:border-neutral-600 dark:text-neutral-400'
+                            }`}
+                        >
+                            <div className="font-medium">{role.name}</div>
+                            <div className="text-xs opacity-70">{role.perspective}</div>
+                        </button>
+                    );
+                })}
+            </div>
+            <button
+                onClick={() => onStart({ interviewers: selected })}
+                className="w-full rounded bg-blue-600 py-2 text-sm text-white hover:bg-blue-700"
+            >
+                면접 시작
+            </button>
+        </div>
+    );
+}

--- a/src/components/QuestionList.tsx
+++ b/src/components/QuestionList.tsx
@@ -75,15 +75,22 @@ export default function QuestionList() {
             {isLoading ? <p className="text-neutral-500">로딩 중...</p> : (
                 <div className="space-y-3">
                     {questions.map(q => (
-                        <a key={q.id} href={`/interview/questions/${q.id}`}
-                            className="block rounded-lg border p-4 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/50">
-                            <h3 className="font-medium">{q.title}</h3>
-                            <div className="mt-1 flex gap-2 text-xs text-neutral-500">
-                                <span className="rounded bg-blue-100 px-1.5 py-0.5 dark:bg-blue-900/30">{q.category}</span>
-                                <span className="rounded bg-green-100 px-1.5 py-0.5 dark:bg-green-900/30">{q.difficulty}</span>
-                                {q.tags.slice(0, 3).map(t => <span key={t} className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-700">{t}</span>)}
-                            </div>
-                        </a>
+                        <div key={q.id} className="flex items-center gap-2">
+                            <a href={`/interview/questions/${q.id}`}
+                                className="block flex-1 rounded-lg border p-4 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800/50">
+                                <h3 className="font-medium">{q.title}</h3>
+                                <div className="mt-1 flex gap-2 text-xs text-neutral-500">
+                                    <span className="rounded bg-blue-100 px-1.5 py-0.5 dark:bg-blue-900/30">{q.category}</span>
+                                    <span className="rounded bg-green-100 px-1.5 py-0.5 dark:bg-green-900/30">{q.difficulty}</span>
+                                    {q.tags.slice(0, 3).map(t => <span key={t} className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-700">{t}</span>)}
+                                </div>
+                            </a>
+                            <a href={`/interview/chat?q=${encodeURIComponent(q.title)}`}
+                                className="shrink-0 rounded-lg border border-blue-600 px-3 py-2 text-sm text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                                title="이 질문으로 면접 시작">
+                                면접
+                            </a>
+                        </div>
                     ))}
                     {questions.length === 0 && <p className="text-neutral-500">질문이 없습니다.</p>}
                 </div>

--- a/src/pages/interview/chat.astro
+++ b/src/pages/interview/chat.astro
@@ -1,16 +1,24 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import InterviewChat from '../../components/InterviewChat';
+import InterviewPage from '../../components/InterviewPage';
 import { getCollection } from 'astro:content';
 
-const questions = await getCollection('questions');
-const randomIdx = Math.floor(Math.random() * questions.length);
-const initialQuestion = questions[randomIdx]?.data.title ?? '면접 질문을 준비 중입니다...';
+// URL 파라미터에서 질문 가져오기 (문제은행에서 온 경우)
+const questionParam = Astro.url.searchParams.get('q') || Astro.url.searchParams.get('question');
+
+let initialQuestion: string;
+if (questionParam) {
+    initialQuestion = questionParam;
+} else {
+    const questions = await getCollection('questions');
+    const randomIdx = Math.floor(Math.random() * questions.length);
+    initialQuestion = questions[randomIdx]?.data.title ?? '면접 질문을 준비 중입니다...';
+}
 ---
 
 <Layout title="AI 모의면접">
     <main class="py-8">
-        <InterviewChat client:load initialQuestion={initialQuestion} />
+        <InterviewPage client:load initialQuestion={initialQuestion} />
     </main>
 </Layout>
 

--- a/src/utils/interview-prompt.ts
+++ b/src/utils/interview-prompt.ts
@@ -9,6 +9,7 @@ interface PromptInput {
     history: ChatMessage[];
     depth: number;
     interviewers?: InterviewerId[];
+    jdContext?: { company: string; jd: string };
 }
 
 export function buildInterviewSystemPrompt(input: PromptInput): string {
@@ -26,6 +27,10 @@ export function buildInterviewSystemPrompt(input: PromptInput): string {
         ).join('\n')}`
         : '';
 
+    const jdSection = input.jdContext
+        ? `\n\n## 기업 맥락\n- 기업: ${input.jdContext.company}\n- 채용공고:\n${input.jdContext.jd}\n\n이 기업의 기술 스택과 채용 요구사항을 고려하여 질문하세요.`
+        : '';
+
     const criteria = SESSION_CONFIG.evaluationCriteria;
 
     return `당신은 AI 모의면접 시스템의 면접관 패널입니다.
@@ -40,7 +45,7 @@ ${interviewerSection}
 
 ## 초기 질문
 ${input.question}
-${ragSection}
+${ragSection}${jdSection}
 
 ## 평가 기준 (${Object.values(criteria).reduce((a, b) => a + b, 0)}점 만점)
 - 정확성: ${criteria.accuracy}점
@@ -107,7 +112,11 @@ ${input.depth >= SESSION_CONFIG.minDepthForFinish
 export function buildFinalFeedbackPrompt(
     history: ChatMessage[],
     scores: number[],
+    interviewers?: InterviewerId[],
 ): string {
+    const activeInterviewers = (interviewers ?? ['frontend', 'backend', 'dba'])
+        .map((id) => INTERVIEWER_ROLES[id])
+        .filter(Boolean);
     return `지금까지의 면접 대화를 종합하여 최종 피드백을 생성하세요.
 
 ## 대화 히스토리
@@ -120,9 +129,12 @@ ${scores.map((s, i) => `Turn ${i + 1}: ${s}점`).join(', ')}
 **"잘한 건 당연한 거라서 의미가 없어요. 미흡한 부분을 조금이라도 고쳐야죠."**
 
 - 칭찬은 최소화하고 비판과 개선점에 집중하세요
-- 각 면접관(frontend/backend/dba)은 자신의 전문 영역에서 구체적인 부족한 점을 지적하세요
+- 각 면접관은 자신의 전문 영역에서 구체적인 부족한 점을 지적하세요
 - 각 면접관이 학습이 필요한 구체적 키워드/주제를 제시하세요
 - "강점"보다 "약점"과 "학습 가이드"를 더 상세하게 작성하세요
+
+## 참여 면접관
+${activeInterviewers.map((r) => `- ${r.id}: ${r.name} (${r.perspective})`).join('\n')}
 
 JSON으로 응답하세요:
 
@@ -136,18 +148,10 @@ JSON으로 응답하세요:
   ],
   "overallFeedback": "종합 피드백 (비판적 관점, 3-5문장)",
   "interviewerComments": {
-    "frontend": {
-      "critique": "프론트엔드 관점에서 부족한 점 (비판적)",
+${activeInterviewers.map((r) => `    "${r.id}": {
+      "critique": "${r.name} 관점에서 부족한 점 (비판적)",
       "studyKeywords": ["학습 필요 키워드1", "학습 필요 키워드2", "학습 필요 키워드3"]
-    },
-    "backend": {
-      "critique": "백엔드 관점에서 부족한 점 (비판적)",
-      "studyKeywords": ["학습 필요 키워드1", "학습 필요 키워드2", "학습 필요 키워드3"]
-    },
-    "dba": {
-      "critique": "DBA 관점에서 부족한 점 (비판적)",
-      "studyKeywords": ["학습 필요 키워드1", "학습 필요 키워드2", "학습 필요 키워드3"]
-    }
+    }`).join(',\n')}
   }
 }
 \`\`\`


### PR DESCRIPTION
## Summary
- 면접 시작 전 면접관 선택 단계 추가 (InterviewSetup → InterviewChat 플로우)
- 최소 1명, 최대 3명 선택 가능 (기본값: 전체 선택)
- 선택된 면접관이 시스템 프롬프트와 최종 피드백에 반영

## Changes
- `src/components/InterviewSetup.tsx`: 면접관 선택 UI (토글 버튼)
- `src/components/InterviewPage.tsx`: setup→chat 래퍼 컴포넌트
- `src/components/InterviewChat.tsx`: `interviewers` prop 추가
- `src/pages/interview/chat.astro`: InterviewPage로 교체
- `src/utils/interview-prompt.ts`: buildFinalFeedbackPrompt에 면접관 필터링

## Test plan
- [ ] 면접관 1명만 선택 → 해당 면접관만 질문
- [ ] 전체 선택 (기본값) → 기존과 동일 동작
- [ ] 최소 1명 제한 동작 확인

Refs: TASK-33