### PR TITLE
feat(interview): 기업 타겟 모의면접 기능

### DIFF
--- a/src/components/InterviewChat.tsx
+++ b/src/components/InterviewChat.tsx
@@ -127,6 +127,11 @@ export default function InterviewChat({ initialQuestion }: Props) {
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const isNearBottomRef = useRef(true); // Start true to auto-scroll initially
 
+    // JD context state
+    const [showJdInput, setShowJdInput] = useState(false);
+    const [companyName, setCompanyName] = useState('');
+    const [jdText, setJdText] = useState('');
+
     const sessionRef = useRef(session);
     useEffect(() => { sessionRef.current = session; }, [session]);
 
@@ -225,12 +230,16 @@ export default function InterviewChat({ initialQuestion }: Props) {
 
             // 3. Build prompt and stream LLM
             const newDepth = sessionRef.current.depth + 1;
+            const jdContext = companyName.trim() || jdText.trim()
+                ? { company: companyName.trim(), jd: jdText.trim() }
+                : undefined;
             const systemPrompt = buildInterviewSystemPrompt({
                 question: sessionRef.current.currentQuestion,
                 userAnswer: answer,
                 chunks,
                 history: updatedMessages,
                 depth: newDepth,
+                jdContext,
             });
 
             // Keep only recent messages to avoid exceeding input token limit
@@ -360,7 +369,7 @@ export default function InterviewChat({ initialQuestion }: Props) {
         } finally {
             setIsLoading(false);
         }
-    }, [input, isLoading, user, apiKey]);
+    }, [input, isLoading, user, apiKey, companyName, jdText, session.currentQuestion, session.scores]);
 
     // --- Render ---
 
@@ -413,6 +422,36 @@ export default function InterviewChat({ initialQuestion }: Props) {
                     >
                         서버 키 모드로 돌아가기
                     </button>
+                </div>
+            )}
+
+            {/* JD 입력 (선택사항) - 면접 시작 전에만 표시 */}
+            {session.messages.length === 0 && (
+                <div className="mb-4 rounded-lg border border-dashed border-neutral-300 p-4 dark:border-neutral-600">
+                    <button
+                        onClick={() => setShowJdInput(!showJdInput)}
+                        className="text-sm font-medium text-neutral-600 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
+                    >
+                        {showJdInput ? '▼ 기업 맥락 접기' : '▶ 기업/채용공고 설정 (선택사항)'}
+                    </button>
+                    {showJdInput && (
+                        <div className="mt-3 space-y-2">
+                            <input
+                                type="text"
+                                placeholder="기업명 (예: 네이버, 카카오)"
+                                value={companyName}
+                                onChange={(e) => setCompanyName(e.target.value)}
+                                className="w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                            />
+                            <textarea
+                                placeholder="채용공고 또는 JD 텍스트 (붙여넣기)"
+                                value={jdText}
+                                onChange={(e) => setJdText(e.target.value)}
+                                rows={4}
+                                className="w-full rounded border px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                            />
+                        </div>
+                    )}
                 </div>
             )}
 

--- a/src/utils/interview-prompt.ts
+++ b/src/utils/interview-prompt.ts
@@ -9,6 +9,7 @@ interface PromptInput {
     history: ChatMessage[];
     depth: number;
     interviewers?: InterviewerId[];
+    jdContext?: { company: string; jd: string };
 }
 
 export function buildInterviewSystemPrompt(input: PromptInput): string {
@@ -26,6 +27,10 @@ export function buildInterviewSystemPrompt(input: PromptInput): string {
         ).join('\n')}`
         : '';
 
+    const jdSection = input.jdContext
+        ? `\n\n## 기업 맥락\n- 기업: ${input.jdContext.company}\n- 채용공고:\n${input.jdContext.jd}\n\n이 기업의 기술 스택과 채용 요구사항을 고려하여 질문하세요.`
+        : '';
+
     const criteria = SESSION_CONFIG.evaluationCriteria;
 
     return `당신은 AI 모의면접 시스템의 면접관 패널입니다.
@@ -40,7 +45,7 @@ ${interviewerSection}
 
 ## 초기 질문
 ${input.question}
-${ragSection}
+${ragSection}${jdSection}
 
 ## 평가 기준 (${Object.values(criteria).reduce((a, b) => a + b, 0)}점 만점)
 - 정확성: ${criteria.accuracy}점


### PR DESCRIPTION
## Summary
- 면접 시작 전 기업명/JD(채용공고) 텍스트 입력 기능 추가 (선택사항)
- JD 컨텍스트가 시스템 프롬프트에 반영되어 기업 맥락 질문 생성
- JD 미입력 시 기존 방식과 동일하게 동작 (하위 호환)

## Changes
- `src/utils/interview-prompt.ts`: `jdContext` 파라미터 추가, JD 섹션 프롬프트 삽입
- `src/components/InterviewChat.tsx`: JD 입력 UI + 상태 관리

## Test plan
- [ ] JD 미입력 → 기존 면접과 동일 동작
- [ ] 기업명 + JD 입력 → 기업 맥락 반영된 질문 확인
- [ ] 면접 시작 후 JD 입력 섹션 숨김 확인

Refs: TASK-26