### PR TITLE
feat: 면접 결과 리포트 및 히스토리 페이지

### DIFF
--- a/netlify/functions/session.mts
+++ b/netlify/functions/session.mts
@@ -43,7 +43,7 @@ export default async (req: Request, _context: Context) => {
         return new Response(null, { status: 204, headers: h });
     }
 
-    if (req.method !== 'POST') {
+    if (req.method !== 'POST' && req.method !== 'GET') {
         return new Response('Method not allowed', { status: 405 });
     }
 
@@ -162,6 +162,58 @@ export default async (req: Request, _context: Context) => {
 
         console.log(JSON.stringify({ ts: new Date().toISOString(), fn: 'session', action: 'complete', session: body.session_id }));
         return new Response(JSON.stringify({ ok: true, status: 'completed' }), { headers: responseHeaders });
+    }
+
+    // --- GET actions: get single session / list sessions ---
+
+    if (body.action === 'get') {
+        if (!body.session_id) {
+            return new Response('Missing session_id', { status: 400, headers: responseHeaders });
+        }
+
+        const { data: session, error: sessionError } = await supabase
+            .from('sessions')
+            .select('*')
+            .eq('id', body.session_id)
+            .eq('user_id', user.id)
+            .single();
+
+        if (sessionError || !session) {
+            return new Response(JSON.stringify({ error: 'Session not found' }), { status: 404, headers: responseHeaders });
+        }
+
+        const { data: messages } = await supabase
+            .from('session_messages')
+            .select('*')
+            .eq('session_id', body.session_id)
+            .order('ordering', { ascending: true });
+
+        return new Response(JSON.stringify({ session, messages: messages ?? [] }), { headers: responseHeaders });
+    }
+
+    if (body.action === 'list') {
+        const limit = Math.min(Number(body.data?.limit ?? 20), 50);
+        const offset = Number(body.data?.offset ?? 0);
+
+        let query = supabase
+            .from('sessions')
+            .select('id, status, initial_question, total_score, feedback, created_at, completed_at', { count: 'exact' })
+            .eq('user_id', user.id)
+            .order('created_at', { ascending: false })
+            .range(offset, offset + limit - 1);
+
+        if (body.data?.status) {
+            query = query.eq('status', String(body.data.status));
+        }
+
+        const { data: sessions, count, error: listError } = await query;
+
+        if (listError) {
+            console.error(JSON.stringify({ ts: new Date().toISOString(), fn: 'session', action: 'list', error: listError.message }));
+            return new Response(JSON.stringify({ error: 'Failed to list sessions' }), { status: 500, headers: responseHeaders });
+        }
+
+        return new Response(JSON.stringify({ sessions: sessions ?? [], total: count ?? 0 }), { headers: responseHeaders });
     }
 
     return new Response(JSON.stringify({ error: 'Unknown action' }), { status: 400, headers: responseHeaders });

--- a/src/components/InterviewChat.tsx
+++ b/src/components/InterviewChat.tsx
@@ -506,12 +506,22 @@ export default function InterviewChat({ initialQuestion, interviewers }: Props) 
             )}
 
             {session.status === 'completed' && (
-                <button
-                    onClick={() => setSession({ ...INITIAL_SESSION_STATE, currentQuestion: initialQuestion })}
-                    className="w-full rounded bg-neutral-200 py-2 text-sm dark:bg-neutral-700"
-                >
-                    새 면접 시작
-                </button>
+                <div className="flex gap-2">
+                    {session.sessionId && (
+                        <a
+                            href={`/interview/result/${session.sessionId}`}
+                            className="flex-1 rounded bg-blue-600 py-2 text-center text-sm text-white hover:bg-blue-700"
+                        >
+                            결과 보기
+                        </a>
+                    )}
+                    <button
+                        onClick={() => setSession({ ...INITIAL_SESSION_STATE, currentQuestion: initialQuestion })}
+                        className="flex-1 rounded bg-neutral-200 py-2 text-sm dark:bg-neutral-700"
+                    >
+                        새 면접 시작
+                    </button>
+                </div>
             )}
         </div>
     );

--- a/src/components/InterviewHistory.tsx
+++ b/src/components/InterviewHistory.tsx
@@ -1,0 +1,158 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../utils/supabase';
+import type { User } from '@supabase/supabase-js';
+
+interface SessionSummary {
+    id: string;
+    status: string;
+    initial_question: string;
+    total_score: number | null;
+    feedback: { totalScore?: number } | null;
+    created_at: string;
+    completed_at: string | null;
+}
+
+type SortKey = 'date' | 'score';
+
+export default function InterviewHistory() {
+    const [user, setUser] = useState<User | null>(null);
+    const [sessions, setSessions] = useState<SessionSummary[]>([]);
+    const [total, setTotal] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [sortBy, setSortBy] = useState<SortKey>('date');
+    const [filterStatus, setFilterStatus] = useState<string>('all');
+
+    useEffect(() => {
+        supabase.auth.getUser().then(({ data: { user: u } }) => {
+            setUser(u);
+            if (u) fetchSessions(u);
+            else setLoading(false);
+        });
+    }, []);
+
+    async function fetchSessions(u: User) {
+        try {
+            const { data: { session: authSession } } = await supabase.auth.getSession();
+            const token = authSession?.access_token;
+            if (!token) return;
+
+            const body: Record<string, unknown> = { action: 'list', data: { limit: 50 } };
+            if (filterStatus !== 'all') body.data = { ...body.data as object, status: filterStatus };
+
+            const res = await fetch('/.netlify/functions/session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify(body),
+            });
+
+            if (res.ok) {
+                const data = await res.json();
+                setSessions(data.sessions);
+                setTotal(data.total);
+            }
+        } catch {
+            // silently fail
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    function handleLogin(provider: 'google' | 'github') {
+        supabase.auth.signInWithOAuth({ provider });
+    }
+
+    if (!user && !loading) {
+        return (
+            <div className="mx-auto max-w-2xl rounded-xl border p-6 dark:border-neutral-700">
+                <h2 className="mb-4 text-xl font-bold">면접 히스토리</h2>
+                <p className="mb-4 text-neutral-600 dark:text-neutral-400">로그인하여 면접 기록을 확인하세요.</p>
+                <div className="flex gap-2">
+                    <button onClick={() => handleLogin('google')} className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">Google 로그인</button>
+                    <button onClick={() => handleLogin('github')} className="rounded bg-neutral-800 px-4 py-2 text-white hover:bg-neutral-900">GitHub 로그인</button>
+                </div>
+            </div>
+        );
+    }
+
+    const sorted = [...sessions].sort((a, b) => {
+        if (sortBy === 'score') {
+            const sa = a.feedback?.totalScore ?? a.total_score ?? 0;
+            const sb = b.feedback?.totalScore ?? b.total_score ?? 0;
+            return sb - sa;
+        }
+        return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+
+    return (
+        <div className="mx-auto max-w-2xl">
+            <div className="mb-6 flex items-center justify-between">
+                <h2 className="text-xl font-bold">면접 히스토리</h2>
+                <a href="/interview/chat" className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">새 면접</a>
+            </div>
+
+            {/* Filters */}
+            <div className="mb-4 flex gap-2">
+                <select
+                    value={filterStatus}
+                    onChange={(e) => { setFilterStatus(e.target.value); if (user) { setLoading(true); fetchSessions(user); } }}
+                    className="rounded border px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                >
+                    <option value="all">전체</option>
+                    <option value="completed">완료</option>
+                    <option value="active">진행중</option>
+                </select>
+                <select
+                    value={sortBy}
+                    onChange={(e) => setSortBy(e.target.value as SortKey)}
+                    className="rounded border px-3 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                >
+                    <option value="date">날짜순</option>
+                    <option value="score">점수순</option>
+                </select>
+                <span className="ml-auto self-center text-xs text-neutral-500">총 {total}건</span>
+            </div>
+
+            {loading ? (
+                <p className="py-8 text-center text-neutral-500">불러오는 중...</p>
+            ) : sorted.length === 0 ? (
+                <div className="rounded-xl border p-8 text-center dark:border-neutral-700">
+                    <p className="text-neutral-500">아직 면접 기록이 없습니다.</p>
+                    <a href="/interview/chat" className="mt-4 inline-block text-sm text-blue-600 underline">첫 면접 시작하기</a>
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    {sorted.map((s) => {
+                        const score = s.feedback?.totalScore ?? s.total_score ?? null;
+                        const isCompleted = s.status === 'completed';
+                        return (
+                            <a
+                                key={s.id}
+                                href={isCompleted ? `/interview/result/${s.id}` : undefined}
+                                className={`block rounded-xl border p-4 transition-colors dark:border-neutral-700 ${isCompleted ? 'hover:bg-neutral-50 dark:hover:bg-neutral-800' : 'opacity-60'}`}
+                            >
+                                <div className="flex items-start justify-between">
+                                    <div className="min-w-0 flex-1">
+                                        <p className="truncate text-sm font-medium">{s.initial_question}</p>
+                                        <div className="mt-1 flex items-center gap-2 text-xs text-neutral-500">
+                                            <span>
+                                                {new Date(s.created_at).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                                            </span>
+                                            <span className={`rounded px-1.5 py-0.5 ${isCompleted ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'}`}>
+                                                {isCompleted ? '완료' : '미완료'}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    {score !== null && (
+                                        <div className={`ml-4 text-2xl font-bold ${score >= 70 ? 'text-green-600' : score >= 40 ? 'text-yellow-600' : 'text-red-600'}`}>
+                                            {score}
+                                        </div>
+                                    )}
+                                </div>
+                            </a>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/InterviewResult.tsx
+++ b/src/components/InterviewResult.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../utils/supabase';
+import { INTERVIEWER_ROLES } from '../config/interviewers';
+import type { User } from '@supabase/supabase-js';
+
+interface SessionData {
+    id: string;
+    status: string;
+    initial_question: string;
+    total_score: number | null;
+    feedback: FeedbackData | null;
+    created_at: string;
+    completed_at: string | null;
+}
+
+interface FeedbackData {
+    totalScore?: number;
+    strengths?: string[];
+    weaknesses?: string[];
+    studyGuide?: { topic: string; reason: string; resources: string[] }[];
+    overallFeedback?: string;
+    interviewerComments?: Record<string, { critique: string; studyKeywords: string[] }>;
+    // Inline feedback fields (from turn-by-turn evaluation)
+    overallScore?: number;
+    evaluations?: { interviewer: string; comment: string; score: Record<string, number> }[];
+    summary?: string;
+}
+
+interface MessageData {
+    id: string;
+    depth: number;
+    role: string;
+    content: string;
+    message_type: string;
+    interviewer: string | null;
+    score: unknown;
+    created_at: string;
+    ordering: number;
+}
+
+interface Props {
+    sessionId: string;
+}
+
+function ScoreBar({ score, max, label }: { score: number; max: number; label: string }) {
+    const pct = Math.round((score / max) * 100);
+    const color = pct >= 70 ? 'bg-green-500' : pct >= 40 ? 'bg-yellow-500' : 'bg-red-500';
+    return (
+        <div className="flex items-center gap-2 text-sm">
+            <span className="w-24 shrink-0 text-neutral-600 dark:text-neutral-400">{label}</span>
+            <div className="h-2 flex-1 rounded-full bg-neutral-200 dark:bg-neutral-700">
+                <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+            </div>
+            <span className="w-12 text-right font-mono text-xs">{score}/{max}</span>
+        </div>
+    );
+}
+
+export default function InterviewResult({ sessionId }: Props) {
+    const [user, setUser] = useState<User | null>(null);
+    const [session, setSession] = useState<SessionData | null>(null);
+    const [messages, setMessages] = useState<MessageData[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        supabase.auth.getUser().then(({ data: { user: u } }) => {
+            setUser(u);
+            if (u) fetchSession(u);
+            else setLoading(false);
+        });
+    }, []);
+
+    async function fetchSession(u: User) {
+        try {
+            const { data: { session: authSession } } = await supabase.auth.getSession();
+            const token = authSession?.access_token;
+            if (!token) { setError('인증 토큰을 가져올 수 없습니다.'); return; }
+
+            const res = await fetch('/.netlify/functions/session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                body: JSON.stringify({ action: 'get', session_id: sessionId }),
+            });
+
+            if (!res.ok) {
+                setError(res.status === 404 ? '면접 기록을 찾을 수 없습니다.' : '데이터를 불러오지 못했습니다.');
+                return;
+            }
+
+            const data = await res.json();
+            setSession(data.session);
+            setMessages(data.messages);
+        } catch {
+            setError('데이터를 불러오는 중 오류가 발생했습니다.');
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    if (loading) {
+        return <div className="mx-auto max-w-2xl p-6 text-center text-neutral-500">불러오는 중...</div>;
+    }
+
+    if (!user) {
+        return (
+            <div className="mx-auto max-w-2xl rounded-xl border p-6 dark:border-neutral-700">
+                <p className="text-neutral-600 dark:text-neutral-400">로그인이 필요합니다.</p>
+                <div className="mt-4 flex gap-2">
+                    <button onClick={() => supabase.auth.signInWithOAuth({ provider: 'google' })} className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700">Google 로그인</button>
+                    <button onClick={() => supabase.auth.signInWithOAuth({ provider: 'github' })} className="rounded bg-neutral-800 px-4 py-2 text-white hover:bg-neutral-900">GitHub 로그인</button>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="mx-auto max-w-2xl rounded-xl border p-6 dark:border-neutral-700">
+                <p className="text-red-600 dark:text-red-400">{error}</p>
+                <a href="/interview/history" className="mt-4 inline-block text-sm text-blue-600 underline">면접 히스토리로 돌아가기</a>
+            </div>
+        );
+    }
+
+    if (!session) return null;
+
+    const feedback = session.feedback;
+    const totalScore = feedback?.totalScore ?? session.total_score ?? 0;
+    const isCompleted = session.status === 'completed';
+
+    // Conversation messages (user answers + assistant questions)
+    const conversationMessages = messages.filter(
+        (m) => m.message_type === 'answer' || m.message_type === 'question' || m.message_type === 'evaluation' || m.message_type === 'feedback'
+    );
+
+    return (
+        <div className="mx-auto max-w-2xl space-y-6">
+            {/* Header */}
+            <div className="rounded-xl border p-6 dark:border-neutral-700">
+                <div className="flex items-start justify-between">
+                    <div>
+                        <h2 className="text-xl font-bold">면접 결과</h2>
+                        <p className="mt-1 text-sm text-neutral-500">
+                            {new Date(session.created_at).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                        </p>
+                    </div>
+                    <div className="text-right">
+                        <div className={`text-3xl font-bold ${totalScore >= 70 ? 'text-green-600' : totalScore >= 40 ? 'text-yellow-600' : 'text-red-600'}`}>
+                            {totalScore}
+                        </div>
+                        <div className="text-xs text-neutral-500">/ 100점</div>
+                    </div>
+                </div>
+                <div className="mt-3 rounded-lg bg-blue-50 p-3 dark:bg-blue-900/20">
+                    <p className="text-sm font-medium text-blue-800 dark:text-blue-200">{session.initial_question}</p>
+                </div>
+                {!isCompleted && (
+                    <p className="mt-2 text-sm text-yellow-600 dark:text-yellow-400">이 면접은 아직 완료되지 않았습니다.</p>
+                )}
+            </div>
+
+            {/* Overall Feedback */}
+            {feedback?.overallFeedback && (
+                <div className="rounded-xl border p-6 dark:border-neutral-700">
+                    <h3 className="mb-3 font-bold">종합 피드백</h3>
+                    <p className="text-sm leading-relaxed text-neutral-700 dark:text-neutral-300">{feedback.overallFeedback}</p>
+                </div>
+            )}
+
+            {/* Strengths & Weaknesses */}
+            {(feedback?.strengths || feedback?.weaknesses) && (
+                <div className="grid gap-4 sm:grid-cols-2">
+                    {feedback.strengths && feedback.strengths.length > 0 && (
+                        <div className="rounded-xl border p-4 dark:border-neutral-700">
+                            <h3 className="mb-2 text-sm font-bold text-green-700 dark:text-green-400">강점</h3>
+                            <ul className="space-y-1 text-sm text-neutral-700 dark:text-neutral-300">
+                                {feedback.strengths.map((s, i) => <li key={i}>- {s}</li>)}
+                            </ul>
+                        </div>
+                    )}
+                    {feedback.weaknesses && feedback.weaknesses.length > 0 && (
+                        <div className="rounded-xl border p-4 dark:border-neutral-700">
+                            <h3 className="mb-2 text-sm font-bold text-red-700 dark:text-red-400">약점</h3>
+                            <ul className="space-y-1 text-sm text-neutral-700 dark:text-neutral-300">
+                                {feedback.weaknesses.map((w, i) => <li key={i}>- {w}</li>)}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {/* Interviewer Comments */}
+            {feedback?.interviewerComments && (
+                <div className="rounded-xl border p-6 dark:border-neutral-700">
+                    <h3 className="mb-4 font-bold">면접관별 피드백</h3>
+                    <div className="space-y-4">
+                        {Object.entries(feedback.interviewerComments).map(([id, comment]) => {
+                            const role = INTERVIEWER_ROLES[id];
+                            return (
+                                <div key={id} className="rounded-lg border p-4 dark:border-neutral-600">
+                                    <div className="mb-2 text-sm font-medium">{role?.name ?? id}</div>
+                                    <p className="text-sm text-neutral-700 dark:text-neutral-300">{comment.critique}</p>
+                                    {comment.studyKeywords?.length > 0 && (
+                                        <div className="mt-2 flex flex-wrap gap-1">
+                                            {comment.studyKeywords.map((kw, i) => (
+                                                <span key={i} className="rounded bg-neutral-100 px-2 py-0.5 text-xs dark:bg-neutral-700">{kw}</span>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+
+            {/* Study Guide */}
+            {feedback?.studyGuide && feedback.studyGuide.length > 0 && (
+                <div className="rounded-xl border p-6 dark:border-neutral-700">
+                    <h3 className="mb-4 font-bold">학습 가이드</h3>
+                    <div className="space-y-3">
+                        {feedback.studyGuide.map((item, i) => (
+                            <div key={i} className="rounded-lg bg-neutral-50 p-3 dark:bg-neutral-800">
+                                <div className="text-sm font-medium">{item.topic}</div>
+                                <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">{item.reason}</p>
+                                {item.resources?.length > 0 && (
+                                    <div className="mt-2 flex flex-wrap gap-1">
+                                        {item.resources.map((r, j) => (
+                                            <span key={j} className="rounded bg-blue-100 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">{r}</span>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* Conversation History */}
+            <div className="rounded-xl border p-6 dark:border-neutral-700">
+                <h3 className="mb-4 font-bold">대화 히스토리</h3>
+                <div className="space-y-3">
+                    {conversationMessages.map((msg, i) => (
+                        <div key={msg.id} className={`rounded-lg p-3 text-sm ${msg.role === 'user' ? 'bg-neutral-100 dark:bg-neutral-800' : 'bg-green-50 dark:bg-green-900/20'}`}>
+                            <span className="text-xs font-medium text-neutral-500">
+                                {msg.role === 'user' ? '나' : msg.interviewer ? `${INTERVIEWER_ROLES[msg.interviewer]?.name ?? msg.interviewer}` : 'AI'}
+                            </span>
+                            <p className="mt-1 whitespace-pre-wrap">{msg.content}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* Navigation */}
+            <div className="flex gap-3">
+                <a href="/interview/history" className="rounded border px-4 py-2 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800">
+                    히스토리 목록
+                </a>
+                <a href="/interview/chat" className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">
+                    새 면접 시작
+                </a>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/interview/history.astro
+++ b/src/pages/interview/history.astro
@@ -1,0 +1,19 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import InterviewHistory from '../../components/InterviewHistory';
+---
+
+<Layout title="면접 히스토리">
+    <main class="py-8">
+        <InterviewHistory client:load />
+    </main>
+</Layout>
+
+<script is:inline>
+    if (!document.querySelector('meta[name="robots"]')) {
+        const meta = document.createElement('meta');
+        meta.name = 'robots';
+        meta.content = 'noindex';
+        document.head.appendChild(meta);
+    }
+</script>

--- a/src/pages/interview/result/[id].astro
+++ b/src/pages/interview/result/[id].astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import InterviewResult from '../../../components/InterviewResult';
+
+export const prerender = false;
+
+const { id } = Astro.params;
+---
+
+<Layout title="면접 결과">
+    <main class="py-8">
+        <InterviewResult client:load sessionId={id!} />
+    </main>
+</Layout>
+
+<script is:inline>
+    if (!document.querySelector('meta[name="robots"]')) {
+        const meta = document.createElement('meta');
+        meta.name = 'robots';
+        meta.content = 'noindex';
+        document.head.appendChild(meta);
+    }
+</script>


### PR DESCRIPTION
## Summary
- TASK-31: 면접 결과 리포트 페이지 (`/interview/result/[id]`)
- TASK-32: 면접 히스토리 목록 페이지 (`/interview/history`)

### Changes
- **session.mts**: `get`/`list` 액션 추가 (세션 단건 조회 + 목록 조회, user_id 필터 적용)
- **InterviewResult.tsx**: 총점, 종합 피드백, 강점/약점, 면접관별 피드백, 학습 가이드, 대화 히스토리 시각화
- **InterviewHistory.tsx**: 날짜순/점수순 정렬, 완료/미완료 필터, 결과 페이지 링크
- **InterviewChat.tsx**: 면접 완료 시 "결과 보기" 버튼 추가
- **[id].astro**: SSR 동적 라우트 (`prerender = false`)

## Test plan
- [ ] 면접 완료 후 "결과 보기" 버튼 → 결과 페이지로 이동 확인
- [ ] 결과 페이지에서 점수, 피드백, 대화 히스토리 표시 확인
- [ ] `/interview/history`에서 과거 면접 목록 조회 확인
- [ ] 미로그인 시 로그인 UI 표시 확인
- [ ] 다른 사용자의 세션 접근 시 404 확인