### PR TITLE
feat(interview): 손해사정사 면접관 카테고리 추가

### DIFF
--- a/src/components/InterviewWidget.tsx
+++ b/src/components/InterviewWidget.tsx
@@ -16,7 +16,7 @@ import ServerKeyBanner from './interview/ServerKeyBanner';
 import InterviewerPicker from './interview/InterviewerPicker';
 import SessionControls from './interview/SessionControls';
 import { INITIAL_SESSION_STATE, SESSION_CONFIG } from '../config/interview-session';
-import type { InterviewerId } from '../config/interviewers';
+import { getInterviewersByCategory, type InterviewerId } from '../config/interviewers';
 
 interface QuestionData extends QuestionEntry {
     data: QuestionEntry['data'] & {
@@ -77,7 +77,7 @@ function InterviewWidgetInner({ questions, posts, user, token }: InnerProps) {
     const [error, setError] = useState<string | null>(null);
 
     // Interviewers
-    const [interviewers, setInterviewers] = useState<InterviewerId[]>(['frontend', 'backend', 'dba']);
+    const [interviewers, setInterviewers] = useState<InterviewerId[]>(() => getInterviewersByCategory('developer'));
 
     // Points
     const [pointBalance, setPointBalance] = useState<number | null>(null);

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 import { supabase } from '../utils/supabase';
 
-const CATEGORIES = ['general', 'java', 'spring', 'database', 'network', 'os', 'design-pattern', 'architecture'];
+const CATEGORIES = [
+    'general', 'java', 'spring', 'database', 'network', 'os', 'design-pattern', 'architecture',
+    'loss-adjuster-law', 'loss-adjuster-claim', 'loss-adjuster-medical',
+];
 
 interface Props {
     editId?: string;

--- a/src/components/QuestionList.tsx
+++ b/src/components/QuestionList.tsx
@@ -11,7 +11,10 @@ interface Question {
     created_at: string;
 }
 
-const CATEGORIES = ['general', 'java', 'spring', 'database', 'network', 'os', 'design-pattern', 'architecture'];
+const CATEGORIES = [
+    'general', 'java', 'spring', 'database', 'network', 'os', 'design-pattern', 'architecture',
+    'loss-adjuster-law', 'loss-adjuster-claim', 'loss-adjuster-medical',
+];
 
 export default function QuestionList() {
     const [questions, setQuestions] = useState<Question[]>([]);

--- a/src/components/interview/InterviewerPicker.tsx
+++ b/src/components/interview/InterviewerPicker.tsx
@@ -1,6 +1,6 @@
 // src/components/interview/InterviewerPicker.tsx
 import { useState } from 'react';
-import { INTERVIEWER_ROLES, type InterviewerId } from '../../config/interviewers';
+import { INTERVIEWER_ROLES, getInterviewersByCategory, type InterviewerId, type InterviewCategory } from '../../config/interviewers';
 
 interface Props {
     selected: InterviewerId[];
@@ -8,10 +8,25 @@ interface Props {
     compact?: boolean;
 }
 
-const ALL_IDS: InterviewerId[] = ['frontend', 'backend', 'dba'];
+const CATEGORY_LABELS: Record<InterviewCategory, string> = {
+    developer: '개발자',
+    lossAdjuster: '손해사정사',
+};
+
+const CATEGORIES: InterviewCategory[] = ['developer', 'lossAdjuster'];
 
 export default function InterviewerPicker({ selected, onChange, compact }: Props) {
     const [expanded, setExpanded] = useState(false);
+    const currentCategory = selected.length > 0
+        ? INTERVIEWER_ROLES[selected[0]]?.category ?? 'developer'
+        : 'developer';
+    const [activeCategory, setActiveCategory] = useState<InterviewCategory>(currentCategory);
+
+    const handleCategoryChange = (cat: InterviewCategory) => {
+        setActiveCategory(cat);
+        const ids = getInterviewersByCategory(cat);
+        onChange([...ids]);
+    };
 
     if (compact && !expanded) {
         return (
@@ -23,7 +38,7 @@ export default function InterviewerPicker({ selected, onChange, compact }: Props
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3">
                     <path d="M10 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM3.465 14.493a1.23 1.23 0 0 0 .41 1.412A9.957 9.957 0 0 0 10 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 0 0-13.074.003Z" />
                 </svg>
-                <span>면접관 {selected.length}명</span>
+                <span>{CATEGORY_LABELS[activeCategory]} {selected.length}명</span>
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3">
                     <path fillRule="evenodd" d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
                 </svg>
@@ -31,9 +46,29 @@ export default function InterviewerPicker({ selected, onChange, compact }: Props
         );
     }
 
+    const categoryIds = getInterviewersByCategory(activeCategory);
+
     return (
         <div className="flex flex-wrap items-center gap-2">
-            {ALL_IDS.map((id) => {
+            {/* Category tabs */}
+            <div className="flex rounded-full border border-neutral-200 dark:border-neutral-700 overflow-hidden">
+                {CATEGORIES.map((cat) => (
+                    <button
+                        key={cat}
+                        onClick={() => handleCategoryChange(cat)}
+                        className={`px-2.5 py-1 text-xs transition-colors ${
+                            activeCategory === cat
+                                ? 'bg-neutral-800 text-white dark:bg-neutral-200 dark:text-neutral-900'
+                                : 'text-neutral-400 hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300'
+                        }`}
+                    >
+                        {CATEGORY_LABELS[cat]}
+                    </button>
+                ))}
+            </div>
+
+            {/* Interviewer pills */}
+            {categoryIds.map((id) => {
                 const role = INTERVIEWER_ROLES[id];
                 const isSelected = selected.includes(id);
                 return (

--- a/src/config/interview-session.ts
+++ b/src/config/interview-session.ts
@@ -1,15 +1,44 @@
-export const SESSION_CONFIG = {
-    maxDepth: 10,
-    minDepthForFinish: 3,
-    searchTopK: 5,
-    similarityThreshold: 0.7,
-    evaluationCriteria: {
+import type { InterviewCategory } from './interviewers';
+
+export const EVALUATION_CRITERIA = {
+    developer: {
         accuracy: 30,
         depth: 25,
         structure: 20,
         practical: 15,
         communication: 10,
     },
+    lossAdjuster: {
+        legalAccuracy: 30,
+        conceptClarity: 25,
+        caseApplication: 25,
+        terminology: 10,
+        communication: 10,
+    },
+} as const;
+
+export const EVALUATION_CRITERIA_LABELS: Record<string, string> = {
+    accuracy: '정확성',
+    depth: '깊이/원리',
+    structure: '구조화',
+    practical: '실무 연결',
+    communication: '커뮤니케이션',
+    legalAccuracy: '법조문/판례 정확성',
+    conceptClarity: '개념 명확성',
+    caseApplication: '사례 적용 능력',
+    terminology: '전문 용어 사용',
+};
+
+export function getEvaluationCriteria(category: InterviewCategory) {
+    return EVALUATION_CRITERIA[category];
+}
+
+export const SESSION_CONFIG = {
+    maxDepth: 10,
+    minDepthForFinish: 3,
+    searchTopK: 5,
+    similarityThreshold: 0.7,
+    evaluationCriteria: EVALUATION_CRITERIA.developer,
 } as const;
 
 export type SessionStatus = 'idle' | 'question_displayed' | 'searching' | 'evaluating' | 'feedback' | 'completed';

--- a/src/config/interviewers.ts
+++ b/src/config/interviewers.ts
@@ -1,6 +1,9 @@
+export type InterviewCategory = 'developer' | 'lossAdjuster';
+
 export interface InterviewerRole {
     id: string;
     name: string;
+    category: InterviewCategory;
     perspective: string;
     focusAreas: string[];
     promptFragment: string;
@@ -10,6 +13,7 @@ export const INTERVIEWER_ROLES: Record<string, InterviewerRole> = {
     frontend: {
         id: 'frontend',
         name: '프론트엔드 면접관',
+        category: 'developer',
         perspective: '사용자 경험, 렌더링 성능, 컴포넌트 설계 관점',
         focusAreas: ['브라우저 동작', 'UI/UX', '상태 관리', '접근성'],
         promptFragment: '프론트엔드 개발자의 관점에서 답변을 평가하세요. 브라우저 동작 원리, 렌더링 최적화, 컴포넌트 설계, 사용자 경험에 초점을 맞추세요.',
@@ -17,6 +21,7 @@ export const INTERVIEWER_ROLES: Record<string, InterviewerRole> = {
     backend: {
         id: 'backend',
         name: '백엔드 면접관',
+        category: 'developer',
         perspective: '서버 성능, 데이터 정합성, 확장성 관점',
         focusAreas: ['API 설계', '동시성', '캐싱', '보안'],
         promptFragment: '백엔드 개발자의 관점에서 답변을 평가하세요. API 설계, 동시성 제어, 데이터 정합성, 시스템 확장성에 초점을 맞추세요.',
@@ -24,10 +29,45 @@ export const INTERVIEWER_ROLES: Record<string, InterviewerRole> = {
     dba: {
         id: 'dba',
         name: 'DBA 면접관',
+        category: 'developer',
         perspective: '데이터 모델링, 쿼리 최적화, 트랜잭션 관점',
         focusAreas: ['인덱싱', '정규화', '락', '복제'],
         promptFragment: 'DBA의 관점에서 답변을 평가하세요. 데이터 모델링, 인덱싱 전략, 쿼리 성능, 트랜잭션 격리 수준에 초점을 맞추세요.',
     },
+    lossAdjusterLaw: {
+        id: 'lossAdjusterLaw',
+        name: '보험법규 면접관',
+        category: 'lossAdjuster',
+        perspective: '보험업법, 보험계약법, 상법 보험편 관점',
+        focusAreas: ['보험업법', '보험계약법', '약관 해석', '보험금 지급 기준'],
+        promptFragment: '보험법규 전문가의 관점에서 답변을 평가하세요. 보험업법/보험계약법 조문 이해, 약관 해석, 보험금 지급/면책 사유, 손해배상 법리에 초점을 맞추세요.',
+    },
+    lossAdjusterClaim: {
+        id: 'lossAdjusterClaim',
+        name: '손해사정 실무 면접관',
+        category: 'lossAdjuster',
+        perspective: '손해액 산정, 보상 실무, 사고 조사 관점',
+        focusAreas: ['손해액 산정', '과실 비율', '보상 절차', '사고 조사'],
+        promptFragment: '손해사정 실무 전문가의 관점에서 답변을 평가하세요. 신체/재물 손해액 산정, 과실 비율 판단, 보험금 산출 과정, 보상 실무 절차에 초점을 맞추세요.',
+    },
+    lossAdjusterMedical: {
+        id: 'lossAdjusterMedical',
+        name: '의학이론 면접관',
+        category: 'lossAdjuster',
+        perspective: '의학 기초, 후유장해, 노동능력상실 관점',
+        focusAreas: ['해부학 기초', '후유장해 평가', '노동능력상실률', '의학 용어'],
+        promptFragment: '의학이론 전문가의 관점에서 답변을 평가하세요. 인체 해부학, 상해 유형별 후유장해 판정, 노동능력상실률 산정, McBride 평가법에 초점을 맞추세요.',
+    },
 } as const;
+
+export function getInterviewersByCategory(category: InterviewCategory): InterviewerId[] {
+    return (Object.keys(INTERVIEWER_ROLES) as InterviewerId[])
+        .filter((id) => INTERVIEWER_ROLES[id].category === category);
+}
+
+export function detectCategory(interviewerIds: InterviewerId[]): InterviewCategory {
+    const first = interviewerIds[0];
+    return first ? INTERVIEWER_ROLES[first]?.category ?? 'developer' : 'developer';
+}
 
 export type InterviewerId = keyof typeof INTERVIEWER_ROLES;

--- a/src/utils/interview-prompt.ts
+++ b/src/utils/interview-prompt.ts
@@ -1,5 +1,5 @@
-import { INTERVIEWER_ROLES, type InterviewerId } from '../config/interviewers';
-import { SESSION_CONFIG } from '../config/interview-session';
+import { INTERVIEWER_ROLES, detectCategory, type InterviewerId } from '../config/interviewers';
+import { SESSION_CONFIG, getEvaluationCriteria, EVALUATION_CRITERIA_LABELS } from '../config/interview-session';
 import type { ChatMessage } from '../config/interview-session';
 
 interface PromptInput {
@@ -13,16 +13,21 @@ interface PromptInput {
 }
 
 export function buildInterviewSystemPrompt(input: PromptInput): string {
-    const activeInterviewers = (input.interviewers ?? ['frontend', 'backend', 'dba'])
+    const ids = input.interviewers ?? ['frontend', 'backend', 'dba'];
+    const activeInterviewers = ids
         .map((id) => INTERVIEWER_ROLES[id])
         .filter(Boolean);
+
+    const category = detectCategory(ids);
+    const criteria = getEvaluationCriteria(category);
+    const isLossAdjuster = category === 'lossAdjuster';
 
     const interviewerSection = activeInterviewers
         .map((r) => `### ${r.name}\n${r.promptFragment}`)
         .join('\n\n');
 
     const ragSection = input.chunks.length > 0
-        ? `\n\n## 지원자 관련 자료 (블로그/프로젝트)\n${input.chunks.map((c) =>
+        ? `\n\n## ${isLossAdjuster ? '관련 참고 자료 (질문 은행/해설)' : '지원자 관련 자료 (블로그/프로젝트)'}\n${input.chunks.map((c) =>
             `- [${c.source}] ${c.title}: ${c.chunk_text.slice(0, 300)}`
         ).join('\n')}`
         : '';
@@ -31,10 +36,38 @@ export function buildInterviewSystemPrompt(input: PromptInput): string {
         ? `\n\n## 기업 맥락\n- 기업: ${input.jdContext.company}\n- 채용공고:\n${input.jdContext.jd}\n\n이 기업의 기술 스택과 채용 요구사항을 고려하여 질문하세요.`
         : '';
 
-    const criteria = SESSION_CONFIG.evaluationCriteria;
+    const criteriaTotal = Object.values(criteria).reduce((a, b) => a + b, 0);
+    const criteriaSection = Object.entries(criteria)
+        .map(([key, val]) => `- ${EVALUATION_CRITERIA_LABELS[key] ?? key}: ${val}점`)
+        .join('\n');
 
-    return `당신은 AI 모의면접 시스템의 면접관 패널입니다.
-다수의 면접관이 각자의 전문 관점에서 지원자를 평가합니다.
+    const interviewerIds = activeInterviewers.map((r) => r.id).join('|');
+
+    const roleDescription = isLossAdjuster
+        ? '손해사정사 시험 면접관 패널'
+        : 'AI 모의면접 시스템의 면접관 패널';
+
+    const questionFlow = isLossAdjuster
+        ? `### 질문 흐름 (순서대로 진행)
+1. **기초 개념 확인**: 법조문, 의학 용어, 핵심 정의 검증
+2. **심화 적용**: 판례 적용, 사례 분석, 산정 방법론 심화
+3. **실무 연결**: 실제 손해사정 사례에 적용, 복합 상황 판단
+
+질문 은행의 모범답안/해설이 있으면 2-3단계에서 적극 활용하세요.`
+        : `### 질문 흐름 (순서대로 진행)
+1. **CS 기초 확인**: 개념의 정의, 기본 원리 검증
+2. **관련 키워드 심화**: 기술적 깊이, 내부 동작 원리, 트레이드오프
+3. **실무 경험 연결**: 지원자의 블로그/프로젝트 자료(RAG)를 활용하여 실제 경험 탐색
+
+지원자의 블로그/프로젝트 자료가 있으면 2-3단계에서 적극 활용하세요.`;
+
+    const scoreKeys = Object.keys(criteria).reduce((acc, key) => {
+        acc[key] = 0;
+        return acc;
+    }, {} as Record<string, number>);
+
+    return `당신은 ${roleDescription}입니다.
+다수의 면접관이 각자의 전문 관점에서 ${isLossAdjuster ? '수험생' : '지원자'}를 평가합니다.
 
 ## 면접관 패널
 ${interviewerSection}
@@ -47,17 +80,13 @@ ${interviewerSection}
 ${input.question}
 ${ragSection}${jdSection}
 
-## 평가 기준 (${Object.values(criteria).reduce((a, b) => a + b, 0)}점 만점)
-- 정확성: ${criteria.accuracy}점
-- 깊이/원리: ${criteria.depth}점
-- 구조화: ${criteria.structure}점
-- 실무 연결: ${criteria.practical}점
-- 커뮤니케이션: ${criteria.communication}점
+## 평가 기준 (${criteriaTotal}점 만점)
+${criteriaSection}
 
 ## 응답 규칙
 
 면접관이 돌아가며 꼬리질문을 합니다.
-**중요: 면접 진행 중에는 평가나 피드백을 지원자에게 직접 말하지 마세요.**
+**중요: 면접 진행 중에는 평가나 피드백을 ${isLossAdjuster ? '수험생' : '지원자'}에게 직접 말하지 마세요.**
 실제 면접처럼, 답변을 듣고 바로 다음 질문으로 넘어가세요.
 
 ### 리액션 규칙
@@ -65,12 +94,7 @@ ${ragSection}${jdSection}
 - 중립적 확인만 허용: "네.", "알겠습니다.", "그렇군요.", "음."
 - 가능한 리액션 생략하고 바로 질문으로 넘어가세요
 
-### 질문 흐름 (순서대로 진행)
-1. **CS 기초 확인**: 개념의 정의, 기본 원리 검증
-2. **관련 키워드 심화**: 기술적 깊이, 내부 동작 원리, 트레이드오프
-3. **실무 경험 연결**: 지원자의 블로그/프로젝트 자료(RAG)를 활용하여 실제 경험 탐색
-
-지원자의 블로그/프로젝트 자료가 있으면 2-3단계에서 적극 활용하세요.
+${questionFlow}
 
 JSON으로 응답하세요:
 
@@ -78,20 +102,20 @@ JSON으로 응답하세요:
 {
   "evaluations": [
     {
-      "interviewer": "frontend|backend|dba",
-      "comment": "내부 평가 메모 (지원자에게 보이지 않음)",
-      "score": { "accuracy": 0, "depth": 0, "structure": 0, "practical": 0, "communication": 0 }
+      "interviewer": "${interviewerIds}",
+      "comment": "내부 평가 메모 (${isLossAdjuster ? '수험생' : '지원자'}에게 보이지 않음)",
+      "score": ${JSON.stringify(scoreKeys)}
     }
   ],
   "followUp": {
     "interviewer": "다음 질문을 하는 면접관 ID",
     "reaction": "중립적 확인만 (예: '네.' / '알겠습니다.' / '그렇군요.') 또는 생략",
     "question": "꼬리질문 내용",
-    "reason": "이 질문을 하는 이유 (내부 메모, 지원자에게 보이지 않음)"
+    "reason": "이 질문을 하는 이유 (내부 메모, ${isLossAdjuster ? '수험생' : '지원자'}에게 보이지 않음)"
   },
   "shouldContinue": true,
   "overallScore": 72,
-  "summary": "내부 종합 평가 메모 (지원자에게 보이지 않음)"
+  "summary": "내부 종합 평가 메모 (${isLossAdjuster ? '수험생' : '지원자'}에게 보이지 않음)"
 }
 \`\`\`
 
@@ -114,9 +138,14 @@ export function buildFinalFeedbackPrompt(
     scores: number[],
     interviewers?: InterviewerId[],
 ): string {
-    const activeInterviewers = (interviewers ?? ['frontend', 'backend', 'dba'])
+    const ids = interviewers ?? ['frontend', 'backend', 'dba'];
+    const activeInterviewers = ids
         .map((id) => INTERVIEWER_ROLES[id])
         .filter(Boolean);
+
+    const category = detectCategory(ids);
+    const isLossAdjuster = category === 'lossAdjuster';
+
     return `지금까지의 면접 대화를 종합하여 최종 피드백을 생성하세요.
 
 ## 대화 히스토리
@@ -144,7 +173,7 @@ JSON으로 응답하세요:
   "strengths": ["강점1", "강점2"],
   "weaknesses": ["약점1", "약점2", "약점3", "약점4"],
   "studyGuide": [
-    { "topic": "학습 주제", "reason": "부족한 이유", "resources": ["추천 키워드1", "추천 키워드2"] }
+    { "topic": "학습 주제", "reason": "부족한 이유", "resources": ["추천 ${isLossAdjuster ? '교재/조문' : '키워드'}1", "추천 ${isLossAdjuster ? '교재/조문' : '키워드'}2"] }
   ],
   "overallFeedback": "종합 피드백 (비판적 관점, 3-5문장)",
   "interviewerComments": {

--- a/supabase/migrations/20260323000000_loss_adjuster_categories.sql
+++ b/supabase/migrations/20260323000000_loss_adjuster_categories.sql
@@ -1,0 +1,75 @@
+-- Loss Adjuster interview question seed data
+-- Categories: loss-adjuster-law, loss-adjuster-claim, loss-adjuster-medical
+
+INSERT INTO interview_questions (title, question, category, difficulty, tags, source)
+VALUES
+  (
+    '고지의무 위반 효과',
+    '보험계약법상 고지의무 위반 시 보험자의 권리와 그 행사 요건을 설명하시오.',
+    'loss-adjuster-law', 2,
+    ARRAY['보험계약법', '고지의무', '계약 해지'],
+    'curated'
+  ),
+  (
+    '손해사정사의 법적 의무',
+    '손해사정사의 법적 의무와 금지행위를 보험업법 조문을 근거로 설명하시오.',
+    'loss-adjuster-law', 2,
+    ARRAY['보험업법', '손해사정사', '금지행위'],
+    'curated'
+  ),
+  (
+    '보험금 지급 기한과 지연이자',
+    '보험업법상 보험금 지급 기한 및 지연이자 규정을 설명하고, 손해사정 완료 후 지급 절차를 서술하시오.',
+    'loss-adjuster-law', 3,
+    ARRAY['보험업법', '보험금 지급', '지연이자'],
+    'curated'
+  ),
+  (
+    '보험계약의 면책사유',
+    '상법 보험편에서 규정하는 주요 면책사유를 유형별로 분류하고 각각의 법적 효과를 설명하시오.',
+    'loss-adjuster-law', 3,
+    ARRAY['상법', '면책사유', '보험금 청구'],
+    'curated'
+  ),
+  (
+    '과실 비율 산정 기준',
+    '교통사고 과실 비율 산정 시 적용되는 기준과 원칙을 설명하고, 주요 판례 경향을 서술하시오.',
+    'loss-adjuster-claim', 3,
+    ARRAY['과실 비율', '교통사고', '손해배상'],
+    'curated'
+  ),
+  (
+    '대물 손해액 산정',
+    '자동차 대물사고 시 손해액 산정 방법(수리비, 시가, 대차료 등)을 설명하시오.',
+    'loss-adjuster-claim', 2,
+    ARRAY['대물 손해', '손해액 산정', '수리비'],
+    'curated'
+  ),
+  (
+    '대인 손해배상 항목',
+    '교통사고 대인배상에서 적극적 손해, 소극적 손해, 위자료의 구분과 각 항목의 산정 방법을 설명하시오.',
+    'loss-adjuster-claim', 3,
+    ARRAY['대인배상', '적극적 손해', '소극적 손해', '위자료'],
+    'curated'
+  ),
+  (
+    '후유장해 등급 판정',
+    '맥브라이드 장해평가법의 기본 원리와 노동능력상실률 산정 방법을 설명하시오.',
+    'loss-adjuster-medical', 3,
+    ARRAY['의학이론', '후유장해', 'McBride'],
+    'curated'
+  ),
+  (
+    '경추부 손상의 분류와 후유증',
+    '경추부 손상의 유형(염좌, 추간판 탈출, 골절)별 특징과 예상되는 후유장해를 설명하시오.',
+    'loss-adjuster-medical', 3,
+    ARRAY['의학이론', '경추', '후유장해'],
+    'curated'
+  ),
+  (
+    '노동능력상실률과 가동연한',
+    '노동능력상실률 산정 시 고려사항과 가동연한 판단 기준을 판례를 근거로 설명하시오.',
+    'loss-adjuster-medical', 4,
+    ARRAY['노동능력상실률', '가동연한', '판례'],
+    'curated'
+  );


### PR DESCRIPTION
## Summary
- 손해사정사 면접관 3종 추가 (보험법규/손해사정 실무/의학이론)
- `InterviewCategory` 타입으로 개발자/손해사정사 그룹 분리
- 카테고리별 평가 기준 분기 (`EVALUATION_CRITERIA`)
- 프롬프트 동적 분기 (역할, 질문 흐름, JSON 스키마)
- `InterviewerPicker`에 카테고리 탭 UI 추가
- 질문 은행에 `loss-adjuster-*` 카테고리 필터 추가
- 손해사정사 시드 질문 10개 마이그레이션

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `src/config/interviewers.ts` | `InterviewCategory` 타입, 손해사정사 3종 면접관, 헬퍼 함수 |
| `src/config/interview-session.ts` | 카테고리별 평가 기준, 라벨, 헬퍼 함수 |
| `src/utils/interview-prompt.ts` | 카테고리별 프롬프트 분기 |
| `src/components/interview/InterviewerPicker.tsx` | 개발자/손해사정사 카테고리 탭 |
| `src/components/InterviewWidget.tsx` | 기본 면접관 동적 초기화 |
| `src/components/QuestionList.tsx` | 카테고리 필터 확장 |
| `src/components/QuestionForm.tsx` | 카테고리 옵션 확장 |
| `supabase/migrations/20260323...sql` | 시드 질문 10개 |

## Test plan
- [x] TypeScript 타입 체크 통과 (기존 e2e 에러만 존재)
- [x] vitest 108개 테스트 전부 통과
- [x] Astro 빌드 성공
- [ ] 손해사정사 면접관 선택 → 질문 → 답변 → 평가 플로우 수동 테스트
- [ ] 개발자 면접관 선택 시 기존과 동일하게 동작하는지 확인