### PR TITLE
fix(blog): 가독성 개선 및 필터 일관성 수정

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -9,7 +9,7 @@ import { SITE } from '../config/site';
 const about = await getEntry('pages', 'about');
 const { Content } = await about.render();
 
-const posts = (await getCollection('blog'))
+const posts = (await getCollection('blog', ({ data }) => data.draft !== true))
     .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
     .slice(0, 3);
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -75,7 +75,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 				</nav>
 			)}
 
-			<div class="prose prose-lg dark:prose-invert max-w-none prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
+			<div class="prose prose-lg dark:prose-invert max-w-prose prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
 				<Content />
 			</div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,9 +5,8 @@ import { getCollection } from 'astro:content';
 import InterviewWidget from '../components/InterviewWidget';
 
 const questions = await getCollection('questions');
-const allPosts = await getCollection('blog');
+const allPosts = await getCollection('blog', ({ data }) => data.draft !== true);
 const posts = allPosts
-    .filter((p) => !p.data.draft)
     .map((p) => ({ slug: p.slug, data: { title: p.data.title, tags: p.data.tags } }));
 
 const questionsData = questions.map((q) => ({

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -162,17 +162,6 @@ html {
     @apply bg-navy-800/50;
 }
 
-/* Prose Paragraph: first-line indent for CJK readability */
-.prose :where(p) {
-    text-indent: 1em;
-}
-
-.prose :where(p):first-child,
-.prose :where(h2, h3, h4) + p,
-.prose :where(blockquote) p,
-.prose :where(li) p {
-    text-indent: 0;
-}
 
 /* Prose Blockquote */
 .prose :where(blockquote) {


### PR DESCRIPTION
## Summary
- about/index 페이지에 draft 필터 적용하여 blog 페이지와 동일 기준 통일
- prose 본문 영역 `max-w-none` → `max-w-prose`로 줄 길이 제한 (65ch)
- `text-indent: 1em` 규칙 제거 (기술 블로그에 부적합)

## Test plan
- [ ] `/about` "최신 글" 섹션이 draft 포스트를 표시하지 않는지 확인
- [ ] 포스트 본문 줄 길이가 65ch로 제한되는지 확인
- [ ] 문단 들여쓰기가 제거되었는지 확인
- [ ] 코드 블록이 overflow-x-auto로 정상 스크롤되는지 확인