### PR TITLE
feat(blog): 읽기 예상 시간 표시

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -2,12 +2,14 @@
 import { type CollectionEntry } from 'astro:content';
 import FormattedDate from './FormattedDate.astro';
 import TagChips from './TagChips.astro';
+import { calculateReadingTime } from '../utils/reading-time';
 
 interface Props {
 	post: CollectionEntry<'blog'>;
 }
 
 const { post } = Astro.props;
+const readingTime = calculateReadingTime(post.body);
 ---
 
 <div class="group py-6 sm:py-8 border-b border-gray-100 dark:border-gray-800 last:border-0 transition-colors duration-200 hover:bg-gray-50/50 dark:hover:bg-white/[0.02] -mx-4 px-4 rounded-lg">
@@ -15,6 +17,7 @@ const { post } = Astro.props;
         <div class="flex items-center justify-between">
             <span class="flex items-center gap-2 text-xs text-gray-400 font-mono uppercase tracking-widest">
                 <FormattedDate date={post.data.pubDate} />
+                <span class="normal-case">· 약 {readingTime}분</span>
                 {post.data.contentSource !== 'original' && (
                     <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-sans font-medium normal-case tracking-normal bg-gray-100 text-gray-500 dark:bg-white/[0.08] dark:text-gray-400">
                         {post.data.contentSource === 'ai-generated' ? 'AI-generated' : 'AI assisted'}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -6,6 +6,7 @@ import BlogSidebar from '../../components/BlogSidebar.astro';
 import Giscus from '../../components/Giscus';
 import AdUnit from '../../components/AdUnit.astro';
 import TagChips from '../../components/TagChips.astro';
+import { calculateReadingTime } from '../../utils/reading-time';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -18,6 +19,7 @@ type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
 const { Content, headings } = await post.render();
+const readingTime = calculateReadingTime(post.body);
 
 const currentTag = post.data.tags?.[0];
 
@@ -46,6 +48,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 			<header class="mb-8 sm:mb-10">
 				<div class="mb-3 sm:mb-4 flex items-center gap-3 text-gray-400 text-sm font-mono">
 					<FormattedDate date={post.data.pubDate} />
+					<span>· 약 {readingTime}분</span>
 					{post.data.contentSource !== 'original' && (
 						<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-sans font-medium bg-gray-100 text-gray-500 dark:bg-white/[0.08] dark:text-gray-400">
 							{post.data.contentSource === 'ai-generated' ? 'AI-generated' : 'AI assisted'}

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,14 @@
+/**
+ * Calculate estimated reading time for text content
+ * @param text - The text content to analyze
+ * @param wordsPerMinute - Reading speed (default: 500 characters per minute for Korean text)
+ * @returns Estimated reading time in minutes
+ */
+export function calculateReadingTime(text: string, wordsPerMinute: number = 500): number {
+	const characterCount = text.length;
+	const minutes = characterCount / wordsPerMinute;
+	const readingTime = Math.ceil(minutes);
+
+	// Return at least 1 minute
+	return readingTime < 1 ? 1 : readingTime;
+}


### PR DESCRIPTION
## Summary
- 블로그 글의 읽기 예상 시간을 계산하는 유틸리티 함수 추가 (`src/utils/reading-time.ts`)
- PostCard(목록)와 글 상세 페이지 헤더에 "약 N분" 형식으로 표시
- 한국어 기준 분당 500자, 최소 1분

## Changes
- `src/utils/reading-time.ts` — 읽기 시간 계산 유틸리티
- `src/components/PostCard.astro` — 발행일 옆에 읽기 시간 표시
- `src/pages/blog/[...slug].astro` — 상세 페이지 헤더에 읽기 시간 표시

## Test plan
- [ ] 블로그 목록에서 각 글 옆에 읽기 시간 표시 확인
- [ ] 글 상세 페이지 헤더에 읽기 시간 표시 확인
- [ ] 짧은 글(1분 미만)이 "약 1분"으로 표시되는지 확인
- [ ] 다크모드에서 스타일 정상 확인