### PR TITLE
feat(blog): 시리즈(연재) 기능 추가

### DIFF
--- a/src/components/SeriesNav.astro
+++ b/src/components/SeriesNav.astro
@@ -1,0 +1,46 @@
+---
+import { getCollection } from 'astro:content';
+
+interface Props {
+    series: string;
+    currentSlug: string;
+}
+
+const { series, currentSlug } = Astro.props;
+
+// Get all posts in the same series
+const allPosts = await getCollection('blog');
+const seriesPosts = allPosts
+    .filter((post) => post.data.series === series && !post.data.draft)
+    .sort((a, b) => {
+        // Sort by seriesOrder if available, otherwise by pubDate
+        if (a.data.seriesOrder !== undefined && b.data.seriesOrder !== undefined) {
+            return a.data.seriesOrder - b.data.seriesOrder;
+        }
+        if (a.data.seriesOrder !== undefined) return -1;
+        if (b.data.seriesOrder !== undefined) return 1;
+        return a.data.pubDate.valueOf() - b.data.pubDate.valueOf();
+    });
+---
+
+<details open class="mb-8 sm:mb-10 p-4 sm:p-5 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-white/[0.02]">
+    <summary class="text-sm font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest cursor-pointer">
+        {series} ({seriesPosts.length}편)
+    </summary>
+    <ol class="mt-3 space-y-1.5 text-sm list-decimal list-inside">
+        {seriesPosts.map((post) => (
+            <li class={post.slug === currentSlug ? 'font-bold text-accent' : 'text-gray-500 dark:text-gray-400'}>
+                {post.slug === currentSlug ? (
+                    <span>{post.data.title}</span>
+                ) : (
+                    <a
+                        href={`/blog/${post.slug}/`}
+                        class="hover:text-accent transition-colors no-underline"
+                    >
+                        {post.data.title}
+                    </a>
+                )}
+            </li>
+        ))}
+    </ol>
+</details>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -40,6 +40,8 @@ const blog = defineCollection({
         project: z.string().optional(),
         contentSource: z.enum(['original', 'ai-generated', 'ai-assisted']).default('ai-assisted'),
         draft: z.boolean().default(false),
+        series: z.string().optional(),
+        seriesOrder: z.number().optional(),
     }),
 });
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -7,6 +7,7 @@ import Giscus from '../../components/Giscus';
 import AdUnit from '../../components/AdUnit.astro';
 import TagChips from '../../components/TagChips.astro';
 import { calculateReadingTime } from '../../utils/reading-time';
+import SeriesNav from '../../components/SeriesNav.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -58,6 +59,11 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 				<h1 class="text-2xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 leading-tight">{post.data.title}</h1>
 				<p class="text-base sm:text-xl text-gray-500 dark:text-gray-400">{post.data.description}</p>
 			</header>
+
+			{/* Series Navigation */}
+			{post.data.series && (
+				<SeriesNav series={post.data.series} currentSlug={post.slug} />
+			)}
 
 			{/* Table of Contents */}
 			{tocHeadings.length > 3 && (


### PR DESCRIPTION
## Summary
- content schema에 `series`(시리즈명) + `seriesOrder`(순번) 필드 추가
- SeriesNav 컴포넌트: 같은 시리즈 글을 `<details/summary>` 접이식 패널로 표시
- 글 상세 페이지의 TOC 위에 시리즈 네비게이션 배치

## Changes
- `src/content/config.ts` — series, seriesOrder 스키마 필드 추가
- `src/components/SeriesNav.astro` — 시리즈 네비게이션 컴포넌트 (신규)
- `src/pages/blog/[...slug].astro` — SeriesNav 배치

## 사용법
```yaml
---
series: "IPC 마스터하기"
seriesOrder: 1
---
```

## Test plan
- [ ] series 필드가 있는 글에서 시리즈 패널 표시 확인
- [ ] series 필드가 없는 기존 글에 영향 없는지 확인
- [ ] 시리즈 내 현재 글 하이라이트 확인
- [ ] 접기/펼치기 동작 확인
- [ ] 다크모드 스타일 확인