### PR TITLE
feat(blog): 페이지네이션 추가

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,106 @@
+---
+import type { Page } from 'astro';
+
+interface Props {
+	page: Page;
+}
+
+const { page } = Astro.props;
+
+// Generate page number array based on current page and total pages
+function getPageNumbers(currentPage: number, lastPage: number): (number | 'ellipsis')[] {
+	if (lastPage <= 7) {
+		return Array.from({ length: lastPage }, (_, i) => i + 1);
+	}
+
+	const pages: (number | 'ellipsis')[] = [];
+
+	// Always show first page
+	pages.push(1);
+
+	// Calculate range around current page
+	const showLeftEllipsis = currentPage > 3;
+	const showRightEllipsis = currentPage < lastPage - 2;
+
+	if (showLeftEllipsis) {
+		pages.push('ellipsis');
+	}
+
+	// Show pages around current page
+	const startPage = Math.max(2, currentPage - 1);
+	const endPage = Math.min(lastPage - 1, currentPage + 1);
+
+	for (let i = startPage; i <= endPage; i++) {
+		pages.push(i);
+	}
+
+	if (showRightEllipsis) {
+		pages.push('ellipsis');
+	}
+
+	// Always show last page
+	pages.push(lastPage);
+
+	return pages;
+}
+
+const pageNumbers = getPageNumbers(page.currentPage, page.lastPage);
+---
+
+<nav class="flex items-center justify-center gap-2 mt-12 mb-8" aria-label="Pagination">
+	<!-- Previous button -->
+	<a
+		href={page.url.prev || '#'}
+		class={`px-3 py-2 font-mono text-sm transition-colors ${
+			page.url.prev
+				? 'text-gray-500 hover:text-accent dark:text-gray-400 dark:hover:text-accent'
+				: 'text-gray-300 dark:text-gray-700 pointer-events-none cursor-default'
+		}`}
+		aria-disabled={!page.url.prev}
+	>
+		« 이전
+	</a>
+
+	<!-- Page numbers -->
+	<div class="flex items-center gap-1">
+		{pageNumbers.map((num) => {
+			if (num === 'ellipsis') {
+				return (
+					<span class="px-2 py-1 text-sm text-gray-400 dark:text-gray-600">
+						...
+					</span>
+				);
+			}
+
+			const isCurrentPage = num === page.currentPage;
+			const pageUrl = num === 1 ? '/blog/' : `/blog/${num}/`;
+
+			return (
+				<a
+					href={pageUrl}
+					class={`min-w-[2rem] px-2 py-1 font-mono text-sm text-center transition-colors ${
+						isCurrentPage
+							? 'bg-accent text-white rounded'
+							: 'text-gray-500 hover:text-accent dark:text-gray-400 dark:hover:text-accent'
+					}`}
+					aria-current={isCurrentPage ? 'page' : undefined}
+				>
+					{num}
+				</a>
+			);
+		})}
+	</div>
+
+	<!-- Next button -->
+	<a
+		href={page.url.next || '#'}
+		class={`px-3 py-2 font-mono text-sm transition-colors ${
+			page.url.next
+				? 'text-gray-500 hover:text-accent dark:text-gray-400 dark:hover:text-accent'
+				: 'text-gray-300 dark:text-gray-700 pointer-events-none cursor-default'
+		}`}
+		aria-disabled={!page.url.next}
+	>
+		다음 »
+	</a>
+</nav>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,17 +1,26 @@
 ---
+import type { GetStaticPaths } from 'astro';
 import { getCollection } from 'astro:content';
 import Layout from '../../layouts/Layout.astro';
 import PostCard from '../../components/PostCard.astro';
 import TagChips from '../../components/TagChips.astro';
 import BlogSidebar from '../../components/BlogSidebar.astro';
+import Pagination from '../../components/Pagination.astro';
 import { getRootTags } from '../../utils/tags';
 import { SITE } from '../../config/site';
 
-const posts = (await getCollection('blog', ({ data }) => data.draft !== true)).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
-);
+export const getStaticPaths = (async ({ paginate }) => {
+	const posts = (await getCollection('blog', ({ data }) => data.draft !== true)).sort(
+		(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+	);
+	return paginate(posts, { pageSize: 10 });
+}) satisfies GetStaticPaths;
 
-const rootTags = getRootTags(posts);
+const { page } = Astro.props;
+
+// Get all posts for tag chips (independent of current page)
+const allPosts = (await getCollection('blog', ({ data }) => data.draft !== true));
+const rootTags = getRootTags(allPosts);
 ---
 
 <Layout title={`블로그 - ${SITE.name}`} description="Java, Spring, 인프라, 아키텍처에 관한 학습 기록">
@@ -25,14 +34,19 @@ const rootTags = getRootTags(posts);
 				</div>
 			)}
 			<div class="flex flex-col">
-				{posts.length > 0 ? (
-					posts.map((post) => (
+				{page.data.length > 0 ? (
+					page.data.map((post) => (
 						<PostCard post={post} />
 					))
 				) : (
 					<p class="text-gray-400 py-12 text-center">아직 작성된 글이 없습니다.</p>
 				)}
 			</div>
+
+			{/* Show pagination only if there are multiple pages */}
+			{page.lastPage > 1 && (
+				<Pagination page={page} />
+			)}
 		</section>
 	</div>
 </Layout>


### PR DESCRIPTION
## Summary
- 블로그 목록을 10개/페이지로 분할하는 페이지네이션 적용
- Astro 내장 `paginate()` 함수 사용
- URL 구조: `/blog/` → `/blog/2/` → `/blog/3/`

## Changes
- `src/components/Pagination.astro` — 페이지 번호 네비게이션 컴포넌트 (신규)
- `src/pages/blog/[...page].astro` — 페이지네이션 적용된 블로그 목록 (신규)
- `src/pages/blog/index.astro` — 삭제 ([...page].astro로 대체)

## Test plan
- [ ] `/blog/` 접속 시 첫 10개 글만 표시되는지 확인
- [ ] `/blog/2/` 접속 시 다음 10개 글 표시 확인
- [ ] 페이지 번호 네비게이션 클릭 동작 확인
- [ ] 이전/다음 버튼 비활성화 상태 확인 (첫/마지막 페이지)
- [ ] 기존 `/blog/` URL 하위 호환 확인
- [ ] 사이드바, 태그 칩 등 기존 UI 유지 확인