### PR TITLE
feat: 소셜 공유 버튼 추가

### DIFF
--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -1,0 +1,97 @@
+---
+interface Props {
+    title: string;
+    url: string;
+}
+const { title, url } = Astro.props;
+const encodedUrl = encodeURIComponent(url);
+const encodedTitle = encodeURIComponent(title);
+---
+
+<div class="flex items-center gap-3 mt-4">
+    <span class="text-xs text-gray-400 font-mono uppercase tracking-widest">공유</span>
+
+    <!-- X (Twitter) -->
+    <a
+        href={`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-gray-400 hover:text-accent transition-colors"
+        aria-label="X(Twitter)에 공유"
+    >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+    </a>
+
+    <!-- LinkedIn -->
+    <a
+        href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedTitle}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-gray-400 hover:text-accent transition-colors"
+        aria-label="LinkedIn에 공유"
+    >
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+    </a>
+
+    <!-- Copy Link -->
+    <button
+        id="copy-link-btn"
+        class="text-gray-400 hover:text-accent transition-colors"
+        aria-label="링크 복사"
+        data-url={url}
+    >
+        <svg id="link-icon" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+        </svg>
+        <svg id="check-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+    </button>
+</div>
+
+<script>
+    // Copy link to clipboard with fallback
+    const copyButton = document.getElementById('copy-link-btn');
+    const linkIcon = document.getElementById('link-icon');
+    const checkIcon = document.getElementById('check-icon');
+
+    if (copyButton && linkIcon && checkIcon) {
+        copyButton.addEventListener('click', async () => {
+            const url = copyButton.getAttribute('data-url');
+            if (!url) return;
+
+            try {
+                // Try modern clipboard API first
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(url);
+                } else {
+                    // Fallback for older browsers or insecure contexts
+                    const textarea = document.createElement('textarea');
+                    textarea.value = url;
+                    textarea.style.position = 'fixed';
+                    textarea.style.left = '-999999px';
+                    document.body.appendChild(textarea);
+                    textarea.select();
+                    document.execCommand('copy');
+                    document.body.removeChild(textarea);
+                }
+
+                // Show check icon for 2 seconds
+                linkIcon.classList.add('hidden');
+                checkIcon.classList.remove('hidden');
+
+                setTimeout(() => {
+                    linkIcon.classList.remove('hidden');
+                    checkIcon.classList.add('hidden');
+                }, 2000);
+            } catch (err) {
+                // Last resort: show URL in prompt
+                prompt('링크를 복사하세요:', url);
+            }
+        });
+    }
+</script>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -8,6 +8,7 @@ import AdUnit from '../../components/AdUnit.astro';
 import TagChips from '../../components/TagChips.astro';
 import { calculateReadingTime } from '../../utils/reading-time';
 import SeriesNav from '../../components/SeriesNav.astro';
+import ShareButtons from '../../components/ShareButtons.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -92,6 +93,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 			{post.data.tags.length > 0 && (
 				<div class="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
 					<TagChips tags={post.data.tags} />
+					<ShareButtons title={post.data.title} url={Astro.url.href} />
 				</div>
 			)}
 


### PR DESCRIPTION
## Summary
- 글 하단 태그 아래에 X(Twitter), LinkedIn, 링크 복사 버튼 추가
- intent URL 방식으로 외부 라이브러리 없이 구현
- 클립보드 복사 실패 시 prompt() fallback

## Changes
- `src/components/ShareButtons.astro` — 공유 버튼 컴포넌트 (신규)
- `src/pages/blog/[...slug].astro` — ShareButtons 배치

## Test plan
- [ ] X 공유 버튼 클릭 시 트윗 작성 화면 열림 확인
- [ ] LinkedIn 공유 버튼 동작 확인
- [ ] 링크 복사 버튼 클릭 시 URL 복사 + 체크마크 피드백 확인
- [ ] 다크모드 스타일 확인