### PR TITLE
feat(blog): 스크롤 진행률 프로그레스 바 추가

### DIFF
--- a/src/components/ScrollProgress.astro
+++ b/src/components/ScrollProgress.astro
@@ -1,0 +1,19 @@
+<div id="scroll-progress" class="fixed top-0 left-0 h-[3px] bg-accent z-50 transition-none" style="width: 0%"></div>
+
+<script>
+	// Calculate progress based on article element
+	const bar = document.getElementById('scroll-progress');
+	const article = document.querySelector('article');
+	if (bar && article) {
+		const update = () => {
+			const rect = article.getBoundingClientRect();
+			const articleTop = rect.top + window.scrollY;
+			const articleHeight = rect.height;
+			const scrolled = window.scrollY - articleTop;
+			const progress = Math.max(0, Math.min(1, scrolled / (articleHeight - window.innerHeight)));
+			bar.style.width = `${progress * 100}%`;
+		};
+		window.addEventListener('scroll', update, { passive: true });
+		update();
+	}
+</script>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -9,6 +9,7 @@ import TagChips from '../../components/TagChips.astro';
 import { calculateReadingTime } from '../../utils/reading-time';
 import SeriesNav from '../../components/SeriesNav.astro';
 import ShareButtons from '../../components/ShareButtons.astro';
+import ScrollProgress from '../../components/ScrollProgress.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -44,6 +45,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 ---
 
 <Layout title={post.data.title} description={post.data.description} image={post.data.heroImage}>
+	<ScrollProgress />
 	<div class="flex gap-0">
 		<BlogSidebar currentTag={currentTag} />
 		<article class="py-8 sm:py-12 pl-8 max-w-3xl min-w-0 grow">


### PR DESCRIPTION
## Summary
- 글 상세 페이지 상단에 3px 프로그레스 바 추가
- 본문(article) 영역 기준 진행률 계산 (댓글/푸터 제외)
- accent 색상, passive scroll listener로 성능 최적화

## Changes
- `src/components/ScrollProgress.astro` — 프로그레스 바 컴포넌트 (신규)
- `src/pages/blog/[...slug].astro` — ScrollProgress 배치

## Test plan
- [ ] 글 상세 페이지에서 스크롤 시 프로그레스 바 동작 확인
- [ ] 본문 끝에서 100% 도달 확인 (댓글 영역 제외)
- [ ] 블로그 목록 등 다른 페이지에서는 표시되지 않는지 확인
- [ ] 다크모드 스타일 확인