### PR TITLE
feat: 맨 위로 가기 버튼 추가

### DIFF
--- a/src/components/ScrollToTop.astro
+++ b/src/components/ScrollToTop.astro
@@ -1,0 +1,28 @@
+<button
+    id="scroll-to-top"
+    class="fixed bottom-6 right-6 z-40 p-3 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:text-accent hover:bg-gray-200 dark:hover:bg-gray-700 transition-all duration-300 opacity-0 pointer-events-none shadow-lg"
+    aria-label="맨 위로"
+>
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"/></svg>
+</button>
+
+<script>
+    const btn = document.getElementById('scroll-to-top');
+    if (btn) {
+        // Show/hide button based on scroll position
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 300) {
+                btn.classList.remove('opacity-0', 'pointer-events-none');
+                btn.classList.add('opacity-100');
+            } else {
+                btn.classList.add('opacity-0', 'pointer-events-none');
+                btn.classList.remove('opacity-100');
+            }
+        }, { passive: true });
+
+        // Scroll to top on click
+        btn.addEventListener('click', () => {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+    }
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import '../../src/styles/globals.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Search from '../components/Search';
+import ScrollToTop from '../components/ScrollToTop.astro';
 import { SITE } from '../config/site';
 
 interface Props {
@@ -71,6 +72,7 @@ const { title, description = SITE.description, image = "/placeholder-social.jpg"
                 <slot />
             </main>
             <Footer />
+            <ScrollToTop />
         </div>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- 우하단 플로팅 "맨 위로" 버튼 추가
- 스크롤 300px 이하에서 숨김, 이후 fadeIn
- Layout.astro에 추가하여 전체 페이지에 적용

## Changes
- `src/components/ScrollToTop.astro` — 맨 위로 버튼 컴포넌트 (신규)
- `src/layouts/Layout.astro` — ScrollToTop 배치

## Test plan
- [ ] 스크롤 300px 이상에서 버튼 나타남 확인
- [ ] 클릭 시 smooth scroll로 최상단 이동 확인
- [ ] 블로그 목록 + 상세 페이지 모두에서 동작 확인
- [ ] 다크모드 스타일 확인