### PR TITLE
feat(seo): BlogPosting JSON-LD 구조화 데이터 추가

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -10,6 +10,7 @@ import { calculateReadingTime } from '../../utils/reading-time';
 import SeriesNav from '../../components/SeriesNav.astro';
 import ShareButtons from '../../components/ShareButtons.astro';
 import ScrollProgress from '../../components/ScrollProgress.astro';
+import { SITE } from '../../config/site';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -46,6 +47,27 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 
 <Layout title={post.data.title} description={post.data.description} image={post.data.heroImage}>
 	<ScrollProgress />
+	<script type="application/ld+json" set:html={JSON.stringify({
+		"@context": "https://schema.org",
+		"@type": "BlogPosting",
+		"headline": post.data.title,
+		"description": post.data.description,
+		"datePublished": post.data.pubDate.toISOString(),
+		"dateModified": (post.data.updatedDate || post.data.pubDate).toISOString(),
+		"author": {
+			"@type": "Person",
+			"name": SITE.name,
+			"url": SITE.url
+		},
+		...(post.data.heroImage && {
+			"image": new URL(post.data.heroImage, SITE.url).toString()
+		}),
+		"url": new URL(`/blog/${post.slug}/`, SITE.url).toString(),
+		"publisher": {
+			"@type": "Person",
+			"name": SITE.name
+		}
+	})} />
 	<div class="flex gap-0">
 		<BlogSidebar currentTag={currentTag} />
 		<article class="py-8 sm:py-12 pl-8 max-w-3xl min-w-0 grow">


### PR DESCRIPTION
## Summary
- 글 상세 페이지에 Schema.org BlogPosting JSON-LD 추가
- 구글 검색 결과 리치 스니펫(작성자, 날짜, 이미지) 노출 지원
- updatedDate 없으면 pubDate로 dateModified fallback

## Changes
- `src/pages/blog/[...slug].astro` — JSON-LD script 태그 추가

## Test plan
- [ ] 글 상세 페이지 소스에서 JSON-LD 스크립트 확인
- [ ] Google Rich Results Test 도구로 유효성 검증
- [ ] heroImage 있는 글/없는 글 모두 정상 출력 확인
- [ ] updatedDate 있는 글/없는 글 dateModified 값 확인