### PR TITLE
feat(blog): 이미지 Lightbox 기능 추가

### DIFF
--- a/src/components/ImageLightbox.astro
+++ b/src/components/ImageLightbox.astro
@@ -1,0 +1,49 @@
+<dialog id="image-lightbox" class="fixed inset-0 z-50 bg-transparent p-0 m-0 max-w-none max-h-none w-full h-full">
+    <div class="flex items-center justify-center w-full h-full bg-black/80 backdrop-blur-sm cursor-pointer" id="lightbox-backdrop">
+        <img id="lightbox-img" class="max-w-[90vw] max-h-[90vh] object-contain rounded-lg shadow-2xl" src="" alt="" />
+    </div>
+</dialog>
+
+<script>
+    // Event delegation on article images
+    const dialog = document.getElementById('image-lightbox') as HTMLDialogElement;
+    const img = document.getElementById('lightbox-img') as HTMLImageElement;
+    const backdrop = document.getElementById('lightbox-backdrop');
+    const article = document.querySelector('article');
+
+    if (dialog && img && backdrop && article) {
+        // Click on images in article prose content
+        article.addEventListener('click', (e) => {
+            const target = e.target as HTMLElement;
+            if (target.tagName === 'IMG' && target.closest('.prose')) {
+                const src = (target as HTMLImageElement).src;
+                const alt = (target as HTMLImageElement).alt;
+                img.src = src;
+                img.alt = alt;
+                dialog.showModal();
+            }
+        });
+
+        // Close on backdrop click
+        backdrop.addEventListener('click', (e) => {
+            if (e.target === backdrop) {
+                dialog.close();
+            }
+        });
+
+        // Close on ESC is built-in with <dialog>
+    }
+</script>
+
+<style>
+    dialog::backdrop {
+        background: transparent;
+    }
+    dialog[open] {
+        animation: fade-in 0.15s ease-out;
+    }
+    @keyframes fade-in {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -11,6 +11,7 @@ import SeriesNav from '../../components/SeriesNav.astro';
 import ShareButtons from '../../components/ShareButtons.astro';
 import ScrollProgress from '../../components/ScrollProgress.astro';
 import { SITE } from '../../config/site';
+import ImageLightbox from '../../components/ImageLightbox.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -109,7 +110,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 				</nav>
 			)}
 
-			<div class="prose prose-lg dark:prose-invert max-w-prose prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
+			<div class="prose prose-lg dark:prose-invert max-w-prose prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl prose-img:cursor-pointer dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
 				<Content />
 			</div>
 
@@ -164,6 +165,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 					<Giscus client:visible />
 				</div>
 			</div>
+			<ImageLightbox />
 		</article>
 	</div>
 </Layout>


### PR DESCRIPTION
## Summary
- 블로그 본문 내 이미지 클릭 시 풀스크린 오버레이로 확대
- HTML <dialog> 기반 구현 (접근성 내장: ESC 닫기, focus trap)
- 외부 라이브러리 없이 직접 구현, fade-in 애니메이션

## Changes
- `src/components/ImageLightbox.astro` — Lightbox 컴포넌트 (신규)
- `src/pages/blog/[...slug].astro` — ImageLightbox 배치 + prose-img:cursor-pointer 추가

## Test plan
- [ ] 글 본문 내 이미지 클릭 시 오버레이 확대 확인
- [ ] ESC 키로 닫기 확인
- [ ] 배경(이미지 외 영역) 클릭으로 닫기 확인
- [ ] 다크모드에서 오버레이 스타일 확인
- [ ] 이미지에 마우스 커서가 pointer로 변경되는지 확인