### PR TITLE
fix: 헤더 텍스트 + 홈 H1 가시화 + CTA 중복 제거

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,7 @@ import ThemeToggle from './ThemeToggle';
     <div class="max-w-7xl mx-auto px-5 sm:px-10 lg:px-24">
         <nav class="flex items-center justify-between py-4 sm:py-6">
             <a href="/" class="text-xl sm:text-2xl font-bold tracking-tight hover:opacity-70 transition-opacity no-underline">
-                {SITE.name}'s
+                {SITE.title}
             </a>
 
             <!-- Desktop Nav -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,10 +18,13 @@ const questionsData = questions.map((q) => ({
 
 <Layout title={SITE.title} description={SITE.description} fullWidth>
     <div class="relative flex flex-1 flex-col items-center px-4">
-        <h1 class="sr-only">{SITE.title} - 기술 면접 연습</h1>
         {/* Full-width gradient background */}
         <div class="pointer-events-none absolute inset-0 bg-gradient-to-b from-accent/[0.08] via-transparent to-transparent dark:from-accent/[0.12]" aria-hidden="true"></div>
         <div class="relative z-10 flex w-full max-w-2xl flex-1 flex-col">
+            <header class="pt-6 pb-2 text-center sm:pt-8">
+                <h1 class="text-3xl sm:text-4xl tracking-tight">{SITE.title}</h1>
+                <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">기술 면접 연습</p>
+            </header>
             <InterviewWidget
                 client:visible
                 questions={questionsData}
@@ -29,10 +32,6 @@ const questionsData = questions.map((q) => ({
                 supabaseUrl={import.meta.env.PUBLIC_SUPABASE_URL}
                 supabaseAnonKey={import.meta.env.PUBLIC_SUPABASE_ANON_KEY}
             />
-            {/* CTA: 기출 제출 유도 */}
-            <p class="mt-4 mb-16 text-center text-xs text-gray-400 dark:text-gray-500">
-                실제 면접 기출이 있나요? <a href="/interview/submit" class="text-accent hover:underline">제출하고 100P 받기 →</a>
-            </p>
         </div>
     </div>
 </Layout>


### PR DESCRIPTION
## Summary

디자인 감사 후속 — Quick Win #4(헤더 텍스트), #5(홈 H1 + CTA 중복) 처리.

- **헤더**: 소유격으로 끝나 어색하던 `chan99k's` → `chan99k's blog`로 완성. `SITE.title`이 이미 정의되어 있어 그대로 활용 (hardcode 회피)
- **홈 H1**: `sr-only`로 시각적 숨김 처리되어 있던 H1을 위젯 위에 visible 노출 + "기술 면접 연습" 부제 추가. 직전 PR의 Newsreader 적용으로 자연스럽게 세리프로 렌더됨
- **CTA 중복 제거**: `index.astro`의 외부 CTA "제출하고 100P 받기"가 `InterviewWidget` 내부에 동일 텍스트로 또 존재했음 → 외부 CTA 제거, 위젯 내부 CTA만 유지

## Why

디자인 감사 발견:
- "헤더 chan99k's 뒤가 비어있음 (소유격으로 끝나서 어색)"
- "홈페이지 H1이 시각적으로 hidden — 방문자가 '이게 무슨 사이트지' 답을 못 받음"
- "100P 받기 CTA 동일 페이지에 2회 중복"

세 가지 모두 첫인상에 직접 영향. 코드 변경량 최소(2 파일, +5/-6).

## Changes

| 파일 | 변경 |
|---|---|
| `src/components/Header.astro` | 로고 텍스트 `{SITE.name}'s` → `{SITE.title}` |
| `src/pages/index.astro` | `sr-only` H1 제거 → visible header 블록 추가, 외부 CTA 제거 |

## Test plan

- [ ] `npm run build` 통과 (로컬 검증 완료)
- [ ] 헤더 좌측에 "chan99k's blog"가 보임
- [ ] 홈페이지 상단에 "chan99k's blog" / "기술 면접 연습" 가시 표시 (Newsreader 세리프)
- [ ] 홈페이지에서 "제출하고 100P 받기" CTA가 1회만 노출 (위젯 내부)
- [ ] 모바일/데스크톱 모두 정상

## Out of scope

- Astro `<Image>` 컴포넌트 전환 (별도)
- 홈페이지 1 viewport 아래 콘텐츠 0인 문제 (블로그 미리보기/프로젝트 미리보기 추가는 별도 디자인 결정)
- `npm audit` 14건 (별도 점검 보고)