### PR TITLE
feat: 블로그 글 가독성/네비게이션 개선

### DIFF
--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -2,13 +2,15 @@
 import { getCollection } from 'astro:content';
 import { buildTagTree, tagToSlug } from '../utils/tags';
 import type { TagTreeNode } from '../utils/tags';
+import type { MarkdownHeading } from 'astro';
 import SidebarTagNode from './SidebarTagNode.astro';
 
 interface Props {
 	currentTag?: string;
+	tocHeadings?: MarkdownHeading[];
 }
 
-const { currentTag } = Astro.props;
+const { currentTag, tocHeadings = [] } = Astro.props;
 
 const posts = await getCollection('blog', ({ data }) => data.draft !== true);
 const tree = buildTagTree(posts);
@@ -34,10 +36,33 @@ function renderTree(node: TagTreeNode, basePath: string = '', depth: number = 0)
 }
 
 const treeData = renderTree(tree);
+const showToc = tocHeadings.length > 1;
 ---
 
-<aside class="hidden lg:block w-48 shrink-0 py-12 pr-6 border-r border-black/[0.06] dark:border-white/[0.06]">
-	<div class="sticky top-24">
+<aside class="hidden lg:block w-56 shrink-0 py-12 pr-6 border-r border-black/[0.06] dark:border-white/[0.06]">
+	<div class="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto pr-2">
+		{showToc && (
+			<nav class="mb-8" aria-label="목차">
+				<h2 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">목차</h2>
+				<ul class="text-sm border-l border-gray-100 dark:border-gray-800">
+					{tocHeadings.map((h) => (
+						<li>
+							<a
+								href={`#${h.slug}`}
+								data-toc-link
+								data-toc-target={h.slug}
+								class:list={[
+									'block py-1 -ml-px border-l-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-accent hover:border-accent transition-colors no-underline leading-snug',
+									h.depth === 3 ? 'pl-6' : 'pl-3',
+								]}
+							>
+								{h.text}
+							</a>
+						</li>
+					))}
+				</ul>
+			</nav>
+		)}
 		<h2 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-4">카테고리</h2>
 		<nav>
 			<a
@@ -55,3 +80,42 @@ const treeData = renderTree(tree);
 		</nav>
 	</div>
 </aside>
+
+{showToc && (
+	<script>
+		const links = document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]');
+		if (links.length > 0) {
+			const linkBySlug = new Map<string, HTMLAnchorElement>();
+			const targets: HTMLElement[] = [];
+			links.forEach((link) => {
+				const slug = link.dataset.tocTarget;
+				if (!slug) return;
+				const el = document.getElementById(slug);
+				if (el) {
+					linkBySlug.set(slug, link);
+					targets.push(el);
+				}
+			});
+
+			const activate = (slug: string) => {
+				linkBySlug.forEach((link, key) => {
+					const isActive = key === slug;
+					link.classList.toggle('text-accent', isActive);
+					link.classList.toggle('border-accent', isActive);
+					link.classList.toggle('font-medium', isActive);
+				});
+			};
+
+			const observer = new IntersectionObserver(
+				(entries) => {
+					const visible = entries
+						.filter((e) => e.isIntersecting)
+						.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0];
+					if (visible?.target.id) activate(visible.target.id);
+				},
+				{ rootMargin: '-80px 0px -70% 0px', threshold: 0 }
+			);
+			targets.forEach((t) => observer.observe(t));
+		}
+	</script>
+)}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -28,17 +28,31 @@ const readingTime = calculateReadingTime(post.body);
 
 const currentTag = post.data.tags?.[0];
 
-// Prev/Next navigation
-const allPosts = (await getCollection('blog'))
+// 전체 published 글 (related posts 후보용)
+const publishedPosts = (await getCollection('blog'))
 	.filter((p) => !p.data.draft)
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
-const currentIndex = allPosts.findIndex((p) => p.slug === post.slug);
-const prevPost = currentIndex < allPosts.length - 1 ? allPosts[currentIndex + 1] : null;
-const nextPost = currentIndex > 0 ? allPosts[currentIndex - 1] : null;
+// 시리즈 글일 때만 prev/next — seriesOrder 기준으로 같은 시리즈 내에서 이동
+let prevPost: typeof publishedPosts[number] | null = null;
+let nextPost: typeof publishedPosts[number] | null = null;
+
+if (post.data.series) {
+	const seriesPosts = publishedPosts
+		.filter((p) => p.data.series === post.data.series)
+		.sort((a, b) => {
+			const ao = a.data.seriesOrder ?? Number.MAX_SAFE_INTEGER;
+			const bo = b.data.seriesOrder ?? Number.MAX_SAFE_INTEGER;
+			if (ao !== bo) return ao - bo;
+			return a.data.pubDate.valueOf() - b.data.pubDate.valueOf();
+		});
+	const idx = seriesPosts.findIndex((p) => p.slug === post.slug);
+	prevPost = idx > 0 ? seriesPosts[idx - 1] : null;
+	nextPost = idx >= 0 && idx < seriesPosts.length - 1 ? seriesPosts[idx + 1] : null;
+}
 
 // Related posts (same tag, excluding current)
-const relatedPosts = allPosts
+const relatedPosts = publishedPosts
 	.filter((p) => p.slug !== post.slug && p.data.tags.some((t: string) => post.data.tags.includes(t)))
 	.slice(0, 3);
 
@@ -70,8 +84,8 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 		}
 	})} />
 	<div class="flex gap-0">
-		<BlogSidebar currentTag={currentTag} />
-		<article class="py-8 sm:py-12 pl-8 max-w-3xl min-w-0 grow">
+		<BlogSidebar currentTag={currentTag} tocHeadings={tocHeadings} />
+		<article class="py-8 sm:py-12 lg:pl-8 max-w-4xl min-w-0 grow">
 			<header class="mb-8 sm:mb-10">
 				<div class="mb-3 sm:mb-4 flex items-center gap-3 text-gray-400 text-sm font-mono">
 					<FormattedDate date={post.data.pubDate} />
@@ -83,7 +97,6 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 					)}
 				</div>
 				<h1 class="text-2xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 leading-tight">{post.data.title}</h1>
-				<p class="text-base sm:text-xl text-gray-500 dark:text-gray-400">{post.data.description}</p>
 			</header>
 
 			{/* Series Navigation */}
@@ -91,26 +104,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 				<SeriesNav series={post.data.series} currentSlug={post.slug} />
 			)}
 
-			{/* Table of Contents */}
-			{tocHeadings.length > 3 && (
-				<nav class="mb-8 sm:mb-10 p-4 sm:p-5 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-white/[0.02]" aria-label="목차">
-					<h2 class="text-sm font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest mb-3">목차</h2>
-					<ul class="space-y-1.5 text-sm">
-						{tocHeadings.map((heading) => (
-							<li class={heading.depth === 3 ? 'ml-4' : ''}>
-								<a
-									href={`#${heading.slug}`}
-									class="text-gray-500 dark:text-gray-400 hover:text-accent transition-colors no-underline"
-								>
-									{heading.text}
-								</a>
-							</li>
-						))}
-					</ul>
-				</nav>
-			)}
-
-			<div class="prose prose-lg dark:prose-invert max-w-prose prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl prose-img:cursor-pointer dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
+			<div class="prose prose-lg dark:prose-invert prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl prose-img:cursor-pointer dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
 				<Content />
 			</div>
 
@@ -122,21 +116,23 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 				</div>
 			)}
 
-			{/* Prev/Next Navigation */}
-			<nav class="mt-8 pt-8 border-t border-gray-100 dark:border-gray-800 grid grid-cols-2 gap-4" aria-label="이전/다음 글">
-				{prevPost ? (
-					<a href={`/blog/${prevPost.slug}/`} class="group block no-underline p-4 rounded-lg border border-gray-100 dark:border-gray-800 hover:border-accent/30 transition-colors">
-						<span class="text-xs text-gray-400 font-mono uppercase tracking-widest">이전 글</span>
-						<p class="text-sm sm:text-base font-medium mt-1 line-clamp-2 group-hover:text-accent transition-colors">{prevPost.data.title}</p>
-					</a>
-				) : <div />}
-				{nextPost ? (
-					<a href={`/blog/${nextPost.slug}/`} class="group block no-underline p-4 rounded-lg border border-gray-100 dark:border-gray-800 hover:border-accent/30 transition-colors text-right">
-						<span class="text-xs text-gray-400 font-mono uppercase tracking-widest">다음 글</span>
-						<p class="text-sm sm:text-base font-medium mt-1 line-clamp-2 group-hover:text-accent transition-colors">{nextPost.data.title}</p>
-					</a>
-				) : <div />}
-			</nav>
+			{/* Prev/Next Navigation — 시리즈 글일 때만 같은 시리즈 내 이동 노출 */}
+			{post.data.series && (prevPost || nextPost) && (
+				<nav class="mt-8 pt-8 border-t border-gray-100 dark:border-gray-800 grid grid-cols-2 gap-4" aria-label="시리즈 이전/다음 글">
+					{prevPost ? (
+						<a href={`/blog/${prevPost.slug}/`} class="group block no-underline p-4 rounded-lg border border-gray-100 dark:border-gray-800 hover:border-accent/30 transition-colors">
+							<span class="text-xs text-gray-400 font-mono uppercase tracking-widest">이전 글</span>
+							<p class="text-sm sm:text-base font-medium mt-1 line-clamp-2 group-hover:text-accent transition-colors">{prevPost.data.title}</p>
+						</a>
+					) : <div />}
+					{nextPost ? (
+						<a href={`/blog/${nextPost.slug}/`} class="group block no-underline p-4 rounded-lg border border-gray-100 dark:border-gray-800 hover:border-accent/30 transition-colors text-right">
+							<span class="text-xs text-gray-400 font-mono uppercase tracking-widest">다음 글</span>
+							<p class="text-sm sm:text-base font-medium mt-1 line-clamp-2 group-hover:text-accent transition-colors">{nextPost.data.title}</p>
+						</a>
+					) : <div />}
+				</nav>
+			)}
 
 			{/* Related Posts */}
 			{relatedPosts.length > 0 && (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -80,18 +80,16 @@
         letter-spacing: -0.02em;
     }
 
-    /* 본문 typography 통일 — line-height/사이즈/weight 일관성 */
+    /* 본문 typography — Tailwind Typography(prose-lg)의 사이즈/리듬은 유지하고
+       한글 가독성을 위한 line-height 만 살짝 늘림. font-size/weight 강제 X. */
     .markdown,
     .prose {
         font-family: var(--font-sans);
-        font-size: 1rem;
-        line-height: 1.7;
     }
 
     .markdown :where(p, li, blockquote, dd, td),
     .prose :where(p, li, blockquote, dd, td) {
-        font-weight: 400;
-        line-height: 1.7;
+        line-height: 1.85;
     }
 
     /* 리스트 폰트 사이즈를 본문과 동일하게 (audit: 14px 27회 등장 문제) */


### PR DESCRIPTION
## 요약

`/blog/bean-overview/` 페이지를 기준으로 보고된 4가지 가독성/네비게이션 이슈를 한 번에 해소합니다.

## 변경 내역

### 1. 상단 description 자동 표시 제거
- frontmatter `description`이 본문 H1 바로 아래에 회색 큰 글씨로 노출되던 것을 제거
- SEO 메타(og/twitter), JSON-LD `BlogPosting.description`, RSS 등 비표시 영역에서는 그대로 사용 → 노출 채널 영향 없음

### 2. 시리즈 기반 prev/next + 비시리즈 글에서는 숨김
- 기존: 전체 블로그를 `pubDate`로 정렬해 prev/next를 뽑음 → 시리즈 글에서 무관한 글로 점프
- 변경: `post.data.series`가 있을 때만 같은 시리즈 내에서 `seriesOrder` 기준으로 prev/next 노출 (`seriesOrder` 미지정 글은 `pubDate`로 fallback). 시리즈가 아닌 글에서는 prev/next 네비게이션 자체를 미렌더
- aria-label도 `이전/다음 글` → `시리즈 이전/다음 글`로 명확화

### 3. 인라인 TOC → 좌측 사이드바 sticky TOC 통합
- 기존: 본문 위에 TOC 카드(`tocHeadings.length > 3` 조건) → 매번 스크롤 위로 돌아가야 함
- 변경: `BlogSidebar`에 TOC 영역 추가, `sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto`로 스크롤 따라옴 + 긴 목차도 사이드바 내부 스크롤 처리
- IntersectionObserver로 현재 보이는 섹션 자동 하이라이트 (border-l + accent color)
- 사이드바 폭 `w-48 → w-56` (h2/h3 들여쓰기 가독성 확보)
- TOC 표시 임계값을 `> 3` → `> 1`로 완화 (사이드바라 본문을 잡아먹지 않음)

### 4. 타이포 오버라이드 정리 + 본문 폭 확대
- `globals.css`의 `.prose { font-size: 1rem; line-height: 1.7 }` 절대값 오버라이드 제거 → `prose-lg`의 18px/1.78 리듬이 정상 적용
- 한글 가독성을 위해 `p, li, blockquote, dd, td`의 `line-height`만 1.85로 미세 조정 (`word-break: keep-all` 환경에서 더 여유 있게)
- 본문 컨테이너 `max-w-3xl` → `max-w-4xl` 확대, 내부 `max-w-prose` 제거 → 우측 빈 여백 흡수

## 영향 범위

- 모든 블로그 상세 페이지 (`src/pages/blog/[...slug].astro`)
- 블로그 사이드바를 사용하는 페이지 (블로그 상세, 태그 페이지 등)
- `.prose` / `.markdown` 클래스가 적용된 모든 본문 — 한글 줄간격이 1.7→1.85로 약간 완화됨

## 검증

- [x] `npx astro build` 통과 (총 6.08s, SSR/정적 라우트 정상)
- [ ] 배포 후 `/blog/bean-overview/` 시각 확인
  - 좌측 사이드바: TOC + 카테고리 모두 sticky 동작
  - 스크롤 시 현재 섹션이 accent 컬러로 하이라이트
  - 본문 너비 확대, 줄간격 여유, 상단 description 블록 사라짐
  - 시리즈 prev/next가 같은 시리즈 글로만 연결
- [ ] 시리즈가 아닌 글 (예: 단독 글) 페이지에서 prev/next nav 미표시 확인