### PR TITLE
fix: 블로그 본문 가로폭을 article 컨테이너 폭과 일치

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -104,7 +104,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 				<SeriesNav series={post.data.series} currentSlug={post.slug} />
 			)}
 
-			<div class="prose prose-lg dark:prose-invert prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl prose-img:cursor-pointer dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
+			<div class="prose prose-lg max-w-none dark:prose-invert prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl prose-img:cursor-pointer dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
 				<Content />
 			</div>
 


### PR DESCRIPTION
## 요약
블로그 상세 페이지에서 SeriesNav 카드는 article 컨테이너(`max-w-4xl`) 폭을 꽉 채우는데 본문(`.prose`)은 Tailwind Typography 기본 제약(`max-width: 65ch`) 때문에 더 좁게 출력되어 시각적 폭 불일치가 발생했습니다.

## 변경
`src/pages/blog/[...slug].astro` prose 컨테이너에 `max-w-none` 추가 → prose 자체 max-width 제거, 부모 폭을 그대로 따라감.

## 영향
- 블로그 상세 페이지 본문 가로폭이 시리즈 카드와 동일하게 ~896px (1.125rem 기준 약 90~95ch)로 확장
- 한 줄이 다소 길어지지만 한글 본문은 어절 구분이 명확해 가독성 영향 제한적
- 다른 페이지(.prose 사용처)는 영향 없음 — 변경은 블로그 상세 라우트로 한정