### PR TITLE
fix: 사이드바 스크롤 제거 / TOC·카테고리 구분 / Giscus 100% 폭

### DIFF
--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -40,9 +40,9 @@ const showToc = tocHeadings.length > 1;
 ---
 
 <aside class="hidden lg:block w-56 shrink-0 py-12 pr-6 border-r border-black/[0.06] dark:border-white/[0.06]">
-	<div class="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto pr-2">
+	<div class="sticky top-24">
 		{showToc && (
-			<nav class="mb-8" aria-label="목차">
+			<nav class="mb-12 pb-8 border-b border-gray-100 dark:border-gray-800" aria-label="목차">
 				<h2 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">목차</h2>
 				<ul class="text-sm border-l border-gray-100 dark:border-gray-800">
 					{tocHeadings.map((h) => (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -211,6 +211,12 @@ html {
 }
 
 
+/* Giscus — iframe은 CSS width 미지정 시 브라우저 기본값(~300px)으로 렌더되므로 강제로 100% */
+.giscus,
+.giscus-frame {
+    width: 100%;
+}
+
 /* Prose Blockquote */
 .prose :where(blockquote) {
     @apply border-l-4 border-accent/40 pl-5 italic text-gray-600 not-italic;


### PR DESCRIPTION
## 요약
블로그 상세 페이지에서 보고된 3가지 시각적 이슈 수정.

## 변경

### 사이드바 (`src/components/BlogSidebar.astro`)
- `max-h-[calc(100vh-7rem)] overflow-y-auto pr-2` 제거 → sticky 컨테이너 자체 스크롤바 사라짐
- TOC 섹션에 `pb-8 border-b` 추가, 카테고리 섹션과 `mb-12`로 간격 확장 → 두 섹션이 명확히 분리

### Giscus 댓글 폭 (`src/styles/globals.css`)
원인: iframe은 CSS에서 `width`를 명시하지 않으면 브라우저 기본값(~300px)으로 렌더됨. giscus client.js는 iframe을 동적 삽입하지만 인라인 스타일로 width를 지정하지 않아 댓글 위젯이 좌측에 좁게 몰림.

수정: `.giscus, .giscus-frame { width: 100% }` 추가 → 부모 컨테이너(article, `max-w-4xl`) 전체 폭을 그대로 사용.

## 영향
- 블로그 상세 페이지 사이드바 (모든 글)
- 블로그 상세 페이지 댓글 영역 (Giscus 사용처)

## 사이드 노트
사이드바 스크롤 제거로 매우 긴 TOC(예: 30+ 항목)에서는 하단 항목이 viewport 아래로 잘릴 수 있음. 해당 케이스가 발견되면 `max-h: none` 유지 + `scrollbar-width: none`(스크롤은 가능하지만 막대 숨김) 방식으로 별도 보강.