### PR TITLE
style: 본문 이미지/표 기본 가운데 정렬

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -181,9 +181,22 @@ html {
     }
 }
 
-/* Prose Table Styles (Programmers-inspired: blue header + clean borders) */
+/* Prose Image — 컨테이너보다 좁은 이미지는 가운데 정렬 (Tailwind Typography prose img는 이미 display:block) */
+.markdown :where(img),
+.prose :where(img) {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* Prose Table Styles (Programmers-inspired: blue header + clean borders)
+   - 표는 내용에 맞는 폭(fit-content)으로 가운데 정렬
+   - 컨테이너보다 넓은 표는 max-width:100%로 안전하게 잘리고, 부모의 prose-table:overflow-x-auto가 가로 스크롤 제공 */
 .prose :where(table) {
-    @apply w-full text-sm border-collapse;
+    @apply text-sm border-collapse;
+    width: fit-content;
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .prose :where(thead th) {


### PR DESCRIPTION
## 요약
블로그 본문에서 이미지와 표를 기본적으로 가운데 정렬되도록 변경.

## 변경 (`src/styles/globals.css`)

### 이미지
```css
.markdown :where(img), .prose :where(img) {
    margin-left: auto;
    margin-right: auto;
}
```
Tailwind Typography가 `prose img`에 `display: block`을 이미 부여하므로 auto margin만 추가하면 컨테이너보다 좁은 이미지는 가운데 위치.

### 표
- `w-full` 제거 → 표가 내용 폭에 맞춰짐
- `width: fit-content` + `margin-left/right: auto` → 가운데 정렬
- `max-width: 100%` → 매우 넓은 표는 컨테이너 폭에서 잘림. 부모의 `prose-table:overflow-x-auto`가 가로 스크롤을 제공하므로 안전.

## 영향 / 트레이드오프
- **작은 표**: 더 보기 좋게 가운데 위치 (이전엔 항상 100% 폭이라 우측 끝까지 늘어남)
- **넓은 표**: 컨테이너 폭에 맞춰지고 필요 시 가로 스크롤 (변경 전과 사실상 동일)
- 기존 글 중 "표가 넓게 펼쳐졌으면" 하는 케이스가 있다면 그 글에서 직접 `<div style="width:100%">`로 감싸거나 별도 테이블 클래스로 보정 가능 (현재 발견 안 됨)