### PR TITLE
feat: 우측 플로팅 TOC 카드 + 본문/사이드바 폭 재배치

### DIFF
--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -2,15 +2,13 @@
 import { getCollection } from 'astro:content';
 import { buildTagTree, tagToSlug } from '../utils/tags';
 import type { TagTreeNode } from '../utils/tags';
-import type { MarkdownHeading } from 'astro';
 import SidebarTagNode from './SidebarTagNode.astro';
 
 interface Props {
 	currentTag?: string;
-	tocHeadings?: MarkdownHeading[];
 }
 
-const { currentTag, tocHeadings = [] } = Astro.props;
+const { currentTag } = Astro.props;
 
 const posts = await getCollection('blog', ({ data }) => data.draft !== true);
 const tree = buildTagTree(posts);
@@ -36,33 +34,10 @@ function renderTree(node: TagTreeNode, basePath: string = '', depth: number = 0)
 }
 
 const treeData = renderTree(tree);
-const showToc = tocHeadings.length > 1;
 ---
 
 <aside class="hidden lg:block w-56 shrink-0 py-12 pr-6 border-r border-black/[0.06] dark:border-white/[0.06]">
 	<div class="sticky top-24">
-		{showToc && (
-			<nav class="mb-12 pb-8 border-b border-gray-100 dark:border-gray-800" aria-label="목차">
-				<h2 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">목차</h2>
-				<ul class="text-sm border-l border-gray-100 dark:border-gray-800">
-					{tocHeadings.map((h) => (
-						<li>
-							<a
-								href={`#${h.slug}`}
-								data-toc-link
-								data-toc-target={h.slug}
-								class:list={[
-									'block py-1 -ml-px border-l-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-accent hover:border-accent transition-colors no-underline leading-snug',
-									h.depth === 3 ? 'pl-6' : 'pl-3',
-								]}
-							>
-								{h.text}
-							</a>
-						</li>
-					))}
-				</ul>
-			</nav>
-		)}
 		<h2 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-4">카테고리</h2>
 		<nav>
 			<a
@@ -80,42 +55,3 @@ const showToc = tocHeadings.length > 1;
 		</nav>
 	</div>
 </aside>
-
-{showToc && (
-	<script>
-		const links = document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]');
-		if (links.length > 0) {
-			const linkBySlug = new Map<string, HTMLAnchorElement>();
-			const targets: HTMLElement[] = [];
-			links.forEach((link) => {
-				const slug = link.dataset.tocTarget;
-				if (!slug) return;
-				const el = document.getElementById(slug);
-				if (el) {
-					linkBySlug.set(slug, link);
-					targets.push(el);
-				}
-			});
-
-			const activate = (slug: string) => {
-				linkBySlug.forEach((link, key) => {
-					const isActive = key === slug;
-					link.classList.toggle('text-accent', isActive);
-					link.classList.toggle('border-accent', isActive);
-					link.classList.toggle('font-medium', isActive);
-				});
-			};
-
-			const observer = new IntersectionObserver(
-				(entries) => {
-					const visible = entries
-						.filter((e) => e.isIntersecting)
-						.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0];
-					if (visible?.target.id) activate(visible.target.id);
-				},
-				{ rootMargin: '-80px 0px -70% 0px', threshold: 0 }
-			);
-			targets.forEach((t) => observer.observe(t));
-		}
-	</script>
-)}

--- a/src/components/TocSidebar.astro
+++ b/src/components/TocSidebar.astro
@@ -1,0 +1,79 @@
+---
+import type { MarkdownHeading } from 'astro';
+
+interface Props {
+	tocHeadings: MarkdownHeading[];
+}
+
+const { tocHeadings } = Astro.props;
+const showToc = tocHeadings.length > 1;
+---
+
+{showToc && (
+	<aside class="hidden xl:block w-60 shrink-0 py-12 pl-6">
+		<div class="sticky top-24">
+			<nav
+				class="rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/60 dark:bg-white/[0.02] px-5 py-5"
+				aria-label="목차"
+			>
+				<h2 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-3">
+					목차
+				</h2>
+				<ul class="text-sm border-l border-gray-200 dark:border-gray-800">
+					{tocHeadings.map((h) => (
+						<li>
+							<a
+								href={`#${h.slug}`}
+								data-toc-link
+								data-toc-target={h.slug}
+								class:list={[
+									'block py-1 -ml-px border-l-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-accent hover:border-accent transition-colors no-underline leading-snug',
+									h.depth === 3 ? 'pl-6' : 'pl-3',
+								]}
+							>
+								{h.text}
+							</a>
+						</li>
+					))}
+				</ul>
+			</nav>
+		</div>
+	</aside>
+
+	<script>
+		const links = document.querySelectorAll<HTMLAnchorElement>('[data-toc-link]');
+		if (links.length > 0) {
+			const linkBySlug = new Map<string, HTMLAnchorElement>();
+			const targets: HTMLElement[] = [];
+			links.forEach((link) => {
+				const slug = link.dataset.tocTarget;
+				if (!slug) return;
+				const el = document.getElementById(slug);
+				if (el) {
+					linkBySlug.set(slug, link);
+					targets.push(el);
+				}
+			});
+
+			const activate = (slug: string) => {
+				linkBySlug.forEach((link, key) => {
+					const isActive = key === slug;
+					link.classList.toggle('text-accent', isActive);
+					link.classList.toggle('border-accent', isActive);
+					link.classList.toggle('font-medium', isActive);
+				});
+			};
+
+			const observer = new IntersectionObserver(
+				(entries) => {
+					const visible = entries
+						.filter((e) => e.isIntersecting)
+						.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0];
+					if (visible?.target.id) activate(visible.target.id);
+				},
+				{ rootMargin: '-80px 0px -70% 0px', threshold: 0 }
+			);
+			targets.forEach((t) => observer.observe(t));
+		}
+	</script>
+)}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -12,6 +12,7 @@ import ShareButtons from '../../components/ShareButtons.astro';
 import ScrollProgress from '../../components/ScrollProgress.astro';
 import { SITE } from '../../config/site';
 import ImageLightbox from '../../components/ImageLightbox.astro';
+import TocSidebar from '../../components/TocSidebar.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -60,7 +61,7 @@ const relatedPosts = publishedPosts
 const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 ---
 
-<Layout title={post.data.title} description={post.data.description} image={post.data.heroImage}>
+<Layout title={post.data.title} description={post.data.description} image={post.data.heroImage} fullWidth>
 	<ScrollProgress />
 	<script type="application/ld+json" set:html={JSON.stringify({
 		"@context": "https://schema.org",
@@ -83,9 +84,10 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 			"name": SITE.name
 		}
 	})} />
-	<div class="flex gap-0">
-		<BlogSidebar currentTag={currentTag} tocHeadings={tocHeadings} />
-		<article class="py-8 sm:py-12 lg:pl-8 max-w-4xl min-w-0 grow">
+	<div class="w-full max-w-screen-2xl mx-auto px-5 sm:px-8 xl:px-10">
+		<div class="flex gap-0">
+			<BlogSidebar currentTag={currentTag} />
+			<article class="py-8 sm:py-12 lg:pl-8 xl:pr-2 flex-1 min-w-0">
 			<header class="mb-8 sm:mb-10">
 				<div class="mb-3 sm:mb-4 flex items-center gap-3 text-gray-400 text-sm font-mono">
 					<FormattedDate date={post.data.pubDate} />
@@ -102,6 +104,28 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 			{/* Series Navigation */}
 			{post.data.series && (
 				<SeriesNav series={post.data.series} currentSlug={post.slug} />
+			)}
+
+			{/* xl 미만 화면용 인라인 목차 (xl+ 에서는 우측 TocSidebar 사용) */}
+			{tocHeadings.length > 1 && (
+				<details class="xl:hidden mb-8 sm:mb-10 rounded-lg border border-gray-100 dark:border-gray-800 bg-gray-50/60 dark:bg-white/[0.02] px-4 py-3">
+					<summary class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-widest cursor-pointer">목차</summary>
+					<ul class="mt-3 text-sm border-l border-gray-200 dark:border-gray-800 space-y-0.5">
+						{tocHeadings.map((h) => (
+							<li>
+								<a
+									href={`#${h.slug}`}
+									class:list={[
+										'block py-1 -ml-px border-l-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-accent hover:border-accent transition-colors no-underline leading-snug',
+										h.depth === 3 ? 'pl-6' : 'pl-3',
+									]}
+								>
+									{h.text}
+								</a>
+							</li>
+						))}
+					</ul>
+				</details>
 			)}
 
 			<div class="prose prose-lg max-w-none dark:prose-invert prose-headings:font-bold prose-headings:text-black dark:prose-headings:text-white prose-a:text-accent prose-img:rounded-xl prose-img:cursor-pointer dark:prose-img:bg-white/90 dark:prose-img:p-2 prose-table:block prose-table:overflow-x-auto">
@@ -163,5 +187,7 @@ const tocHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 			</div>
 			<ImageLightbox />
 		</article>
+			<TocSidebar tocHeadings={tocHeadings} />
+		</div>
 	</div>
 </Layout>


### PR DESCRIPTION
## 요약
목차를 좌측 사이드바에서 분리해 **우측 sticky 플로팅 카드**로 재배치하고, 사이드바를 뷰포트 가장자리에 더 가깝게 두면서 본문 폭을 확장하는 방향으로 레이아웃 재구성.

## 변경 사항

### 신규 컴포넌트
- `src/components/TocSidebar.astro`
  - 우측 `w-60 sticky top-24` 카드형 TOC
  - 카드 스타일: rounded-lg border + bg-gray-50/60 + padding
  - IntersectionObserver로 현재 보이는 섹션 자동 하이라이트
  - **xl+ (1280px+)** 에서만 표시

### `src/components/BlogSidebar.astro` (간소화)
- TOC 섹션, `tocHeadings` prop, IntersectionObserver 스크립트 제거
- 카테고리 전용으로 원복

### `src/pages/blog/[...slug].astro`
- `<Layout fullWidth>` + 자체 wrapper `max-w-screen-2xl mx-auto px-5 sm:px-8 xl:px-10`
  - 기존 `lg:px-24` 대비 외곽 padding 축소 → 사이드바가 뷰포트 가장자리에 더 근접
  - 기존 `max-w-7xl(1280)` → `max-w-screen-2xl(1536)`로 확대 → 큰 모니터에서 양쪽 사이드바가 더 바깥으로
- `<article>` 의 `max-w-4xl` 제거, `flex-1 min-w-0`으로 변경 → 사이드바 사이 잔여 폭을 그대로 사용
- xl 미만 fallback: 본문 상단에 접힌 `<details>` 인라인 TOC (`xl:hidden`)

## 브레이크포인트별 표시
| 화면 | 좌 카테고리 | 본문 | 우 TOC 카드 | 인라인 TOC |
|---|---|---|---|---|
| xl+ (≥1280) | ✓ | ✓ | ✓ | 숨김 |
| lg ~ xl 미만 | ✓ | ✓ | 숨김 | 본문 상단 details |
| <lg | 숨김 | ✓ | 숨김 | 본문 상단 details |

## 폭 예산 (대략)
| 모니터 | wrapper 사용폭 | 본문 폭 |
|---|---|---|
| 1920px | 1456 | ~944px (~52ch) |
| 1440px | 1360 | ~848px (~47ch) |
| 1280px | 1200 | ~688px (~38ch) |
| 1024px (lg) | 976 (TOC 미표시) | ~728px |

## 영향 범위
블로그 상세 라우트(`src/pages/blog/[...slug].astro`)에 한정. 다른 페이지(블로그 리스트, 태그, 홈 등)는 기존 `Layout`의 `max-w-7xl px-24` 그대로 유지.